### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/Sources/xcbeautify/Version.swift
+++ b/Sources/xcbeautify/Version.swift
@@ -1,1 +1,1 @@
-let version = "1.0.1"
+let version = "1.1.0"


### PR DESCRIPTION
Before introducing the next changes, bump to 1.1.0. 

As part of a separate effort...

• I'm going to find a way to automatically bump the version file value
• I'm going to ensure that a tag can't be assigned to a commit where the file value doesn't match