### PR TITLE
Remove SPM Installation Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,16 @@ let package = Package(
     name: "BuildTools",
     platforms: [.macOS(.v10_11)],
     dependencies: [
-      .package(url: "https://github.com/cpisciotta/xcbeautify", from: "1.7.0"),
+      .package(url: "https://github.com/cpisciotta/xcbeautify", from: "2.11.0"),
     ],
     targets: [
-      .target(name: "BuildTools", path: "")
+        .target(
+            name: "BuildTools",
+            dependencies: [
+                .product(name: "xcbeautify", package: "xcbeautify"),
+            ],
+            path: ""
+        )
     ]
 )
 ```

--- a/README.md
+++ b/README.md
@@ -49,15 +49,14 @@ import PackageDescription
 
 let package = Package(
     name: "BuildTools",
-    platforms: [.macOS(.v10_11)],
     dependencies: [
-      .package(url: "https://github.com/cpisciotta/xcbeautify", from: "2.11.0"),
+      .package(url: "https://github.com/cpisciotta/xcbeautify", from: "2.23.0"), // Update as needed to the latest version
     ],
     targets: [
         .target(
             name: "BuildTools",
             dependencies: [
-                .product(name: "xcbeautify", package: "xcbeautify"),
+                .product(name: "XcbeautifyLib", package: "xcbeautify"),
             ],
             path: ""
         )

--- a/README.md
+++ b/README.md
@@ -37,38 +37,6 @@ brew install xcbeautify
 mint install cpisciotta/xcbeautify
 ```
 
-### Swift Package Manager
-
-Create a directory in the same location as the `xcodeproj` file, for example `BuildTools`.  
-In that directory, create a `Package.swift` file with the following contents.  
-In addition, add an empty file named `Empty.swift` to the same location.
-
-```swift
-// swift-tools-version: 5.9
-import PackageDescription
-
-let package = Package(
-    name: "BuildTools",
-    dependencies: [
-      .package(url: "https://github.com/cpisciotta/xcbeautify", from: "2.23.0"), // Update as needed to the latest version
-    ],
-    targets: [
-        .target(
-            name: "BuildTools",
-            dependencies: [
-                .product(name: "XcbeautifyLib", package: "xcbeautify"),
-            ],
-            path: ""
-        )
-    ]
-)
-```
-
-Enter this command to execute.  
-```
-swift run -c release --package-path ./BuildTools xcbeautify
-```
-
 ### Build from source
 
 ```bash


### PR DESCRIPTION
Update example Package.swift for dependencies that the command builds on Swift 6 using:

```
swift run -c release --package-path ./BuildTools xcbeautify
```