### PR TITLE
Add support for Macro Target output

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -2529,3 +2529,19 @@ struct DataModelCodegenCaptureGroup: CaptureGroup {
         self.project = project
     }
 }
+
+struct MacroTargetCaptureGroup: CaptureGroup {
+    static let outputType: OutputType = .task
+
+    /// Regular expression captured groups:
+    /// $1 = package
+    static let regex = XCRegex(pattern: #"^(.*) Target '(.*)' must be enabled before it can be used.$"#)
+
+    let package: String
+
+    init?(groups: [String]) {
+        assert(groups.count == 2)
+        guard let package = groups[safe: 1] else { return nil }
+        self.package = package
+    }
+}

--- a/Sources/XcbeautifyLib/Formatter.swift
+++ b/Sources/XcbeautifyLib/Formatter.swift
@@ -143,6 +143,8 @@ package struct Formatter {
             return renderer.formatLinkerUndefinedSymbolsError(group: group)
         case let group as LinkingCaptureGroup:
             return renderer.formatLinking(group: group)
+        case let group as MacroTargetCaptureGroup:
+            return renderer.formatMacroTarget(group: group)
         case let group as ModuleIncludesErrorCaptureGroup:
             return renderer.formatError(group: group)
         case let group as NoCertificateCaptureGroup:

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -141,6 +141,7 @@ package final class Parser {
         NonPCHClangCommandCaptureGroup.self,
         NoteCaptureGroup.self,
         DataModelCodegenCaptureGroup.self,
+        MacroTargetCaptureGroup.self,
     ]
 
     #if DEBUG

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -57,6 +57,7 @@ protocol OutputRendering {
     func formatLinkerUndefinedSymbolLocation(group: LinkerUndefinedSymbolLocationCaptureGroup) -> String?
     func formatLinkerUndefinedSymbolsError(group: LinkerUndefinedSymbolsCaptureGroup) -> String
     func formatLinking(group: LinkingCaptureGroup) -> String
+    func formatMacroTarget(group: MacroTargetCaptureGroup) -> String
     func formatNonPCHClangCommand(group: NonPCHClangCommandCaptureGroup) -> String?
     func formatPackageCheckingOut(group: PackageCheckingOutCaptureGroup) -> String
     func formatPackageEnd() -> String
@@ -770,5 +771,10 @@ extension OutputRendering {
 
     func formatDataModelCodegen(group: DataModelCodegenCaptureGroup) -> String {
         colored ? "[\(group.target.f.Cyan)] \("DataModelCodegen".s.Bold) \(group.path)" : "[\(group.target)] DataModelCodegen \(group.path)"
+    }
+
+    func formatMacroTarget(group: MacroTargetCaptureGroup) -> String {
+        let message = "must be enabled before it can be used."
+        return colored ? "[\(group.package.f.Cyan)] \(message.s.Bold)" : "[\(group.package)] \(message)"
     }
 }

--- a/Tests/XcbeautifyLibTests/ParserTests.swift
+++ b/Tests/XcbeautifyLibTests/ParserTests.swift
@@ -493,4 +493,10 @@ final class ParserTests: XCTestCase {
             XCTAssertNil(parser.parse(line: input))
         }
     }
+
+    func testMacroTarget() throws {
+        let input = #"/path/to/Package.swift:PACKAGE-TARGET:MacroPackage: error: Target 'MacroPackage' must be enabled before it can be used."#
+        let captureGroup = try XCTUnwrap(parser.parse(line: input) as? MacroTargetCaptureGroup)
+        XCTAssertEqual(captureGroup.package, "MacroPackage")
+    }
 }

--- a/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
@@ -805,4 +805,9 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
         let formatted = logFormatted("DataModelCodegen /path/to/data/model/something.xcdatamodeld (in target 'Target' from project 'Project')")
         XCTAssertEqual(formatted, "[Target] DataModelCodegen /path/to/data/model/something.xcdatamodeld")
     }
+
+    func testMacroTarget() {
+        let formatted = logFormatted("/Swallow/Package.swift:PACKAGE-TARGET:SwallowMacros: error: Target 'SwallowMacros' must be enabled before it can be used.")
+        XCTAssertEqual(formatted, "[SwallowMacros] must be enabled before it can be used.")
+    }
 }

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -802,4 +802,9 @@ final class GitHubActionsRendererTests: XCTestCase {
         let formatted = logFormatted("DataModelCodegen /path/to/data/model/something.xcdatamodeld (in target 'Target' from project 'Project')")
         XCTAssertEqual(formatted, "[Target] DataModelCodegen /path/to/data/model/something.xcdatamodeld")
     }
+
+    func testMacroTarget() {
+        let formatted = logFormatted("/Swallow/Package.swift:PACKAGE-TARGET:SwallowMacros: error: Target 'SwallowMacros' must be enabled before it can be used.")
+        XCTAssertEqual(formatted, "[SwallowMacros] must be enabled before it can be used.")
+    }
 }

--- a/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
@@ -807,4 +807,9 @@ final class TeamCityRendererTests: XCTestCase {
         let formatted = noColoredFormatted("DataModelCodegen /path/to/data/model/something.xcdatamodeld (in target 'Target' from project 'Project')")
         XCTAssertEqual(formatted, "[Target] DataModelCodegen /path/to/data/model/something.xcdatamodeld")
     }
+
+    func testMacroTarget() {
+        let formatted = noColoredFormatted("/Swallow/Package.swift:PACKAGE-TARGET:SwallowMacros: error: Target 'SwallowMacros' must be enabled before it can be used.")
+        XCTAssertEqual(formatted, "[SwallowMacros] must be enabled before it can be used.")
+    }
 }

--- a/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
@@ -839,4 +839,9 @@ final class TerminalRendererTests: XCTestCase {
         let formatted = noColoredFormatted("DataModelCodegen /path/to/data/model/something.xcdatamodeld (in target 'Target' from project 'Project')")
         XCTAssertEqual(formatted, "[Target] DataModelCodegen /path/to/data/model/something.xcdatamodeld")
     }
+
+    func testMacroTarget() {
+        let formatted = noColoredFormatted("/Swallow/Package.swift:PACKAGE-TARGET:SwallowMacros: error: Target 'SwallowMacros' must be enabled before it can be used.")
+        XCTAssertEqual(formatted, "[SwallowMacros] must be enabled before it can be used.")
+    }
 }


### PR DESCRIPTION
Closes https://github.com/cpisciotta/xcbeautify/issues/341.

### Changes

Add a capture group for the Macro Target output.

### Testing

- Added new unit tests