### PR TITLE
Migrate to JUnit Protocol

### DIFF
--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -114,7 +114,7 @@ struct Xcbeautify: ParsableCommand {
                 continue
             }
 
-            if report.contains(.junit) {
+            if report.contains(.junit), let captureGroup = captureGroup as? any JUnitReportable {
                 junitReporter.add(captureGroup: captureGroup)
             }
 

--- a/Tests/XcbeautifyLibTests/JUnitReporterTests.swift
+++ b/Tests/XcbeautifyLibTests/JUnitReporterTests.swift
@@ -228,7 +228,7 @@ class JUnitReporterTests: XCTestCase {
         let reporter = JUnitReporter()
 
         for line in try String(contentsOf: url).components(separatedBy: .newlines) {
-            if let captureGroup = parser.parse(line: line) {
+            if let captureGroup = parser.parse(line: line) as? any JUnitReportable {
                 reporter.add(captureGroup: captureGroup)
             }
         }
@@ -292,7 +292,7 @@ class JUnitReporterTests: XCTestCase {
         let reporter = JUnitReporter()
 
         for line in try String(contentsOf: url).components(separatedBy: .newlines) {
-            if let captureGroup = parser.parse(line: line) {
+            if let captureGroup = parser.parse(line: line) as? any JUnitReportable {
                 reporter.add(captureGroup: captureGroup)
             }
         }
@@ -798,7 +798,7 @@ class JUnitReporterTests: XCTestCase {
         let reporter = JUnitReporter()
 
         for line in try String(contentsOf: url).components(separatedBy: .newlines) {
-            if let captureGroup = parser.parse(line: line) {
+            if let captureGroup = parser.parse(line: line) as? any JUnitReportable {
                 reporter.add(captureGroup: captureGroup)
             }
         }
@@ -821,7 +821,7 @@ class JUnitReporterTests: XCTestCase {
         let reporter = JUnitReporter()
 
         for line in try String(contentsOf: inputURL).components(separatedBy: .newlines) {
-            if let captureGroup = parser.parse(line: line) {
+            if let captureGroup = parser.parse(line: line) as? any JUnitReportable {
                 reporter.add(captureGroup: captureGroup)
             }
         }


### PR DESCRIPTION
Update `CaptureGroup` definitions such that they self-define `JUnit` conformance.