### PR TITLE
Add TeamCity test directives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ package-darwin-universal:
 	$(SWIFT) build $(ARM64_SWIFT_BUILD_FLAGS)
 
 	$(eval RELEASE_DIR := release)
-	mkdir $(RELEASE_DIR)
+	$(MKDIR) $(RELEASE_DIR)
 
 	lipo -create -output "$(RELEASE_DIR)/$(PRODUCT_NAME)" "$(X86_64_BUILD_DIRECTORY)/$(PRODUCT_NAME)" "$(ARM64_BUILD_DIRECTORY)/$(PRODUCT_NAME)"
 

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -36,6 +36,17 @@ protocol CompileFileCaptureGroup: CaptureGroup {
     var target: String { get }
 }
 
+protocol SuiteTestCaseNamer: CaptureGroup {
+    var suite: String { get }
+    var testCase: String { get }
+}
+
+
+protocol PlainTestCaseNamer: CaptureGroup {
+    var testName: String { get }
+}
+
+
 protocol CopyCaptureGroup: CaptureGroup {
     var file: String { get }
     var target: String { get }
@@ -885,7 +896,7 @@ struct LinkingCaptureGroup: CaptureGroup {
     }
 }
 
-struct TestCaseSkippedCaptureGroup: CaptureGroup, JUnitReportable {
+struct TestCaseSkippedCaptureGroup: CaptureGroup, JUnitReportable, SuiteTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// Regular expression captured groups:
@@ -916,7 +927,7 @@ struct TestCaseSkippedCaptureGroup: CaptureGroup, JUnitReportable {
     }
 }
 
-struct TestCasePassedCaptureGroup: CaptureGroup, JUnitReportable {
+struct TestCasePassedCaptureGroup: CaptureGroup, JUnitReportable, SuiteTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// Regular expression captured groups:
@@ -947,7 +958,7 @@ struct TestCasePassedCaptureGroup: CaptureGroup, JUnitReportable {
     }
 }
 
-struct TestCaseStartedCaptureGroup: CaptureGroup {
+struct TestCaseStartedCaptureGroup: CaptureGroup, SuiteTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// Regular expression captured groups:
@@ -970,7 +981,7 @@ struct TestCaseStartedCaptureGroup: CaptureGroup {
     }
 }
 
-struct TestCaseMeasuredCaptureGroup: CaptureGroup {
+struct TestCaseMeasuredCaptureGroup: CaptureGroup, SuiteTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// $1 = suite
@@ -1001,7 +1012,7 @@ struct TestCaseMeasuredCaptureGroup: CaptureGroup {
     }
 }
 
-struct ParallelTestCaseSkippedCaptureGroup: CaptureGroup, JUnitParallelReportable {
+struct ParallelTestCaseSkippedCaptureGroup: CaptureGroup, JUnitParallelReportable, SuiteTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// Regular expression captured groups:
@@ -1031,7 +1042,7 @@ struct ParallelTestCaseSkippedCaptureGroup: CaptureGroup, JUnitParallelReportabl
     }
 }
 
-struct ParallelTestCasePassedCaptureGroup: CaptureGroup, JUnitParallelReportable {
+struct ParallelTestCasePassedCaptureGroup: CaptureGroup, JUnitParallelReportable, SuiteTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// Regular expression captured groups:
@@ -1061,7 +1072,7 @@ struct ParallelTestCasePassedCaptureGroup: CaptureGroup, JUnitParallelReportable
     }
 }
 
-struct ParallelTestCaseAppKitPassedCaptureGroup: CaptureGroup {
+struct ParallelTestCaseAppKitPassedCaptureGroup: CaptureGroup, SuiteTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// Regular expression captured groups:
@@ -1083,7 +1094,7 @@ struct ParallelTestCaseAppKitPassedCaptureGroup: CaptureGroup {
     }
 }
 
-struct ParallelTestCaseFailedCaptureGroup: CaptureGroup, JUnitParallelReportable {
+struct ParallelTestCaseFailedCaptureGroup: CaptureGroup, JUnitParallelReportable, SuiteTestCaseNamer {
     static let outputType: OutputType = .error
 
     /// Regular expression captured groups:
@@ -2250,7 +2261,7 @@ struct SwiftTestingSuiteStartedCaptureGroup: CaptureGroup, JUnitParallelReportab
     }
 }
 
-struct SwiftTestingTestStartedCaptureGroup: CaptureGroup {
+struct SwiftTestingTestStartedCaptureGroup: CaptureGroup, PlainTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture the start of a test case.
@@ -2312,7 +2323,7 @@ struct SwiftTestingSuiteFailedCaptureGroup: CaptureGroup {
     }
 }
 
-struct SwiftTestingTestFailedCaptureGroup: CaptureGroup, JUnitParallelReportable {
+struct SwiftTestingTestFailedCaptureGroup: CaptureGroup, JUnitParallelReportable, PlainTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture the failure of a test case.
@@ -2341,7 +2352,7 @@ struct SwiftTestingTestFailedCaptureGroup: CaptureGroup, JUnitParallelReportable
     }
 }
 
-struct SwiftTestingTestPassedCaptureGroup: CaptureGroup, JUnitParallelReportable {
+struct SwiftTestingTestPassedCaptureGroup: CaptureGroup, JUnitParallelReportable, PlainTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture the successful completion of a test case.
@@ -2366,7 +2377,7 @@ struct SwiftTestingTestPassedCaptureGroup: CaptureGroup, JUnitParallelReportable
     }
 }
 
-struct SwiftTestingTestSkippedCaptureGroup: CaptureGroup, JUnitParallelReportable {
+struct SwiftTestingTestSkippedCaptureGroup: CaptureGroup, JUnitParallelReportable, PlainTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture a skipped test case.
@@ -2387,7 +2398,7 @@ struct SwiftTestingTestSkippedCaptureGroup: CaptureGroup, JUnitParallelReportabl
     }
 }
 
-struct SwiftTestingTestSkippedReasonCaptureGroup: CaptureGroup, JUnitParallelReportable {
+struct SwiftTestingTestSkippedReasonCaptureGroup: CaptureGroup, JUnitParallelReportable, PlainTestCaseNamer {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture a skipped test case with a reason.

--- a/Sources/XcbeautifyLib/Formatter.swift
+++ b/Sources/XcbeautifyLib/Formatter.swift
@@ -33,6 +33,8 @@ package struct Formatter {
         }
     }
 
+    package func formatEndOfStream() -> String? { renderer.formatEndOfStream() }
+
     package func format(captureGroup: any CaptureGroup) -> String? {
         switch captureGroup {
         case let group as AggregateTargetCaptureGroup:

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -127,6 +127,8 @@ protocol OutputRendering {
     func formatSwiftDriverCompilationTarget(group: SwiftDriverCompilationTarget) -> String?
     func formatMkDirCaptureGroup(group: MkDirCaptureGroup) -> String?
     func formatNote(group: NoteCaptureGroup) -> String
+
+    func formatEndOfStream() -> String?
 }
 
 extension OutputRendering {
@@ -771,4 +773,6 @@ extension OutputRendering {
     func formatDataModelCodegen(group: DataModelCodegenCaptureGroup) -> String {
         colored ? "[\(group.target.f.Cyan)] \("DataModelCodegen".s.Bold) \(group.path)" : "[\(group.target)] DataModelCodegen \(group.path)"
     }
+
+    func formatEndOfStream() -> String? { nil }
 }

--- a/Sources/XcbeautifyLib/Renderers/TeamCityRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/TeamCityRenderer.swift
@@ -260,11 +260,11 @@ struct TeamCityRenderer: OutputRendering {
    }
 
    func formatSwiftTestingSuitePassed(group: SwiftTestingSuitePassedCaptureGroup) -> String {
-        "##teamcity[testSuiteFinished name='\(group.suiteName.teamCityEscaped())']'"
+        "##teamcity[testSuiteFinished name='\(group.suiteName.teamCityEscaped())']"
    }
 
    func formatSwiftTestingTestPassed(group: SwiftTestingTestPassedCaptureGroup) -> String {
-        outputTeamCityTestPlainDirective("testFinished", group, extra: " duration='\(group.timeTaken.sToMs())']")
+        outputTeamCityTestPlainDirective("testFinished", group, extra: " duration='\(group.timeTaken.sToMs())'")
    }
 
     func formatSwiftTestingSuiteFailed(group: SwiftTestingSuiteFailedCaptureGroup) -> String {

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -122,6 +122,8 @@ struct Xcbeautify: ParsableCommand {
             output.write(captureGroup.outputType, formatted)
         }
 
+        formatter.formatEndOfStream().map { output.write(.test, $0) }
+
         if !report.isEmpty {
             let outputPath = URL(
                 fileURLWithPath: reportPath,

--- a/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
@@ -357,42 +357,72 @@ final class TeamCityRendererTests: XCTestCase {
 
     func testParallelTestCaseFailed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'xctest (49438)' (0.131 seconds)")
-        XCTAssertEqual(formatted, "    ✖ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, """
+        ##teamcity[testStarted name='XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests']
+        ##teamcity[testMetadata testName='XcbeautifyLibTests:testBuildTarget' name='device' value='Device xctest (49438)']
+        ##teamcity[testFailed name='XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests']
+        ##teamcity[testFinished name='XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests' duration='131']
+        """)
     }
 
     func testParallelTestCasePassed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'xctest (49438)' (0.131 seconds)")
-        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, """
+        ##teamcity[testStarted name='XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests']
+        ##teamcity[testMetadata testName='XcbeautifyLibTests:testBuildTarget' name='device' value='Device xctest (49438)']
+
+        ##teamcity[testFinished name='XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests' duration='131']
+        """)
     }
 
     func testConcurrentDestinationTestSuiteStarted() {
         let formatted = noColoredFormatted("Test suite 'XcbeautifyLibTests (iOS).xctest' started on 'iPhone X'")
-        XCTAssertEqual(formatted, "Test Suite XcbeautifyLibTests (iOS).xctest started on 'iPhone X'")
+        XCTAssertEqual(formatted, "##teamcity[testSuiteStarted name='XcbeautifyLibTests (iOS).xctest' flowId='XcbeautifyLibTests (iOS).xctest']")
     }
 
     func testConcurrentDestinationTestCaseFailed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'iPhone X' (77.158 seconds)")
-        XCTAssertEqual(formatted, "    ✖ [XcbeautifyLibTests] testBuildTarget on 'iPhone X' (77.158 seconds)")
+        XCTAssertEqual(formatted, """
+        ##teamcity[testStarted name='XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests']
+        ##teamcity[testMetadata testName='XcbeautifyLibTests:testBuildTarget' name='device' value='Device iPhone X']
+        ##teamcity[testFailed name='XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests']
+        ##teamcity[testFinished name='XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests' duration='77158']
+        """)
     }
 
     func testConcurrentDestinationTestCasePassed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'iPhone X' (77.158 seconds)")
-        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'iPhone X' (77.158 seconds)")
+        XCTAssertEqual(formatted, """
+        ##teamcity[testStarted name='XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests']
+        ##teamcity[testMetadata testName='XcbeautifyLibTests:testBuildTarget' name='device' value='Device iPhone X']
+
+        ##teamcity[testFinished name='XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests' duration='77158']
+        """)
     }
 
     func testParallelTestCaseAppKitPassed() {
         let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed on 'xctest (49438)' (0.131 seconds).")
-        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
+        XCTAssertEqual(formatted, """
+        ##teamcity[testStarted name='XcbeautifyLibTests.XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests.XcbeautifyLibTests']
+        ##teamcity[testMetadata testName='XcbeautifyLibTests.XcbeautifyLibTests:testBuildTarget' name='device' value='AppKit']
+
+        ##teamcity[testFinished name='XcbeautifyLibTests.XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests.XcbeautifyLibTests' duration='131']
+        """)
     }
 
     func testParallelTestCaseAppKitWithSpacesPassed() {
         let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests test build target]' passed on 'xctest (49438)' (0.131 seconds).")
-        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] test build target (0.131 seconds)")
+        XCTAssertEqual(formatted, """
+        ##teamcity[testStarted name='XcbeautifyLibTests.XcbeautifyLibTests:test build target' flowId='XcbeautifyLibTests.XcbeautifyLibTests']
+        ##teamcity[testMetadata testName='XcbeautifyLibTests.XcbeautifyLibTests:test build target' name='device' value='AppKit']
+
+        ##teamcity[testFinished name='XcbeautifyLibTests.XcbeautifyLibTests:test build target' flowId='XcbeautifyLibTests.XcbeautifyLibTests' duration='131']
+        """)
     }
 
     func testParallelTestingStarted() {
         let formatted = noColoredFormatted("Testing started on 'iPhone X'")
-        XCTAssertEqual(formatted, "Testing started on 'iPhone X'")
+        XCTAssertEqual(formatted, "##teamcity[testRetrySupport enabled='true']")
     }
 
     func testParallelTestingPassed() {
@@ -725,7 +755,7 @@ final class TeamCityRendererTests: XCTestCase {
 
     func testTestingStarted() {
         let formatted = noColoredFormatted(#"Testing started"#)
-        XCTAssertEqual(formatted, #"Testing started"#)
+        XCTAssertEqual(formatted, #"##teamcity[testRetrySupport enabled='true']"#)
     }
 
     func testSwiftTestingRunFailed() {
@@ -739,25 +769,34 @@ final class TeamCityRendererTests: XCTestCase {
         let input = #"􀢄 Suite "MyTestSuite" failed after 8.456 seconds with 2 issues."#
         let formatted = noColoredFormatted(input)
 
-        XCTAssertEqual(formatted, "##teamcity[message text=\'Suite failed\' errorDetails=\'\"MyTestSuite\" failed after 8.456 seconds with 2 issue(s)\' status=\'ERROR\']\nSuite failed")
+        XCTAssertEqual(formatted, """
+        ##teamcity[testSuiteFinished name='"MyTestSuite"']
+        """)
     }
 
     func testSwiftTestingTestFailed() {
         let input = #"􀢄 Test "myTest" failed after 1.234 seconds with 1 issue."#
         let formatted = noColoredFormatted(input)
-        XCTAssertEqual(formatted, "##teamcity[message text=\'Test failed\' errorDetails=\'\"myTest\" (1.234 seconds) 1 issue(s)\' status=\'ERROR\']\nTest failed")
+        XCTAssertEqual(formatted, """
+        ##teamcity[testFailed name='"myTest"' message='1 issues']
+        ##teamcity[testFinished name='"myTest"' duration='1234']
+        """)
     }
 
     func testSwiftTestingTestSkipped() {
         let input = #"􀙟 Test "myTest" skipped."#
         let formatted = noColoredFormatted(input)
-        XCTAssertEqual(formatted, "##teamcity[message text=\'Test skipped|n\"myTest\"\' status=\'WARNING\']\nTest skipped")
+        XCTAssertEqual(formatted, """
+        ##teamcity[testIgnored name='"myTest"']
+        """)
     }
 
     func testSwiftTestingTestSkippedReason() {
         let input = #"􀙟 Test "myTest" skipped: "Reason for skipping""#
         let formatted = noColoredFormatted(input)
-        XCTAssertEqual(formatted, "##teamcity[message text=\'Test skipped|n\"myTest\" (Reason for skipping)\' status=\'WARNING\']\nTest skipped")
+        XCTAssertEqual(formatted, """
+        ##teamcity[testIgnored name='"myTest"' details=' (Reason for skipping)']
+        """)
     }
 
     func testSwiftTestingIssue() {

--- a/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
@@ -375,6 +375,35 @@ final class TeamCityRendererTests: XCTestCase {
         """)
     }
 
+    func testParallelTestCaseSkipped() {
+        let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' skipped on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, "##teamcity[testIgnored name='XcbeautifyLibTests:testBuildTarget' flowId='XcbeautifyLibTests']")
+    }
+
+    func testSwiftTestingSuiteStarted() {
+        let input = #"􀟈 Suite MyTestSuite started."#
+        let output = "##teamcity[testSuiteStarted name='MyTestSuite']"
+        XCTAssertEqual(noColoredFormatted(input), output)
+    }
+
+    func testSwiftTestingSuitePassed() {
+        let input = #"􁁛 Suite MyTestSuite passed after 5.123 seconds."#
+        let output = "##teamcity[testSuiteFinished name='MyTestSuite']"
+        XCTAssertEqual(noColoredFormatted(input), output)
+    }
+
+    func testSwiftTestingTestStarted() {
+        let input = #"􁁛 Test myTest passed after 0.678 seconds."#
+        let output = "##teamcity[testFinished name='myTest' duration='678']"
+        XCTAssertEqual(noColoredFormatted(input), output)
+    }
+
+    func testSwiftTestingTestPassed() {
+        let input = #"􁁛 Test myTest passed after 0.678 seconds."#
+        let output = "##teamcity[testFinished name='myTest' duration='678']"
+        XCTAssertEqual(noColoredFormatted(input), output)
+    }
+
     func testConcurrentDestinationTestSuiteStarted() {
         let formatted = noColoredFormatted("Test suite 'XcbeautifyLibTests (iOS).xctest' started on 'iPhone X'")
         XCTAssertEqual(formatted, "##teamcity[testSuiteStarted name='XcbeautifyLibTests (iOS).xctest' flowId='XcbeautifyLibTests (iOS).xctest']")
@@ -433,6 +462,26 @@ final class TeamCityRendererTests: XCTestCase {
     func testParallelTestingFailed() {
         let formatted = noColoredFormatted("Testing failed on 'iPhone X'")
         XCTAssertEqual(formatted, "Testing failed on 'iPhone X'")
+    }
+
+    func testParallelTestSuiteStarted() {
+        let formatted = noColoredFormatted("Test suite 'boobah' started on 'my frog'")
+        XCTAssertEqual(formatted, "##teamcity[testSuiteStarted name='boobah' flowId='boobah']")
+    }
+
+    func testEndOfStream() {
+        // Clear buildup from other tests
+        _ = noColoredFormatted("Test suite 'ex' started on 'my frog'")
+        _ = noColoredFormatted(#"Testing started"#)
+
+        // Start two suites, to see their ends at EOF
+        _ = noColoredFormatted("Test suite 'why' started on 'my frog'")
+        _ = noColoredFormatted("Test suite 'zed' started on 'my frog'")
+        let formatted = formatter.formatEndOfStream()
+        XCTAssertEqual(formatted, """
+        ##teamcity[testSuiteFinished name='why' flowId='why']
+        ##teamcity[testSuiteFinished name='zed' flowId='zed']
+        """)
     }
 
     func testPbxcp() {


### PR DESCRIPTION
This relates to [issue 421](https://github.com/cpisciotta/xcbeautify/issues/421) - about using the test-specific directives like ##teamcity[testSuiteStarted ... ] instead of just ##teamcity[message] directives.

It occurs to me that this should probably be a separate renderer: some folks might prefer the message based one, and to use junit or some other test integration for counting tests.