### PR TITLE
Add Github Actions file references for Swift Testing issues

### DIFF
--- a/Sources/XcbeautifyLib/Renderers/Microsoft/MicrosoftOutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/Microsoft/MicrosoftOutputRendering.swift
@@ -249,12 +249,12 @@ extension MicrosoftOutputRendering {
             }
         }
 
-        let message: String
-        if let detailMessage, !detailMessage.isEmpty {
-            message = "Recorded an issue (\(detailMessage))"
-        } else {
-            message = "Recorded an issue"
-        }
+        let message =
+            if let detailMessage, !detailMessage.isEmpty {
+                "Recorded an issue (\(detailMessage))"
+            } else {
+                "Recorded an issue"
+            }
         return makeOutputLog(
             annotation: .error,
             fileComponents: fileComponents,

--- a/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
@@ -758,7 +758,7 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
     func testSwiftTestingIssue() {
         let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
         let formatted = logFormatted(input)
-        let expectedOutput = "##vso[task.logissue type=error]Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
+        let expectedOutput = "##vso[task.logissue type=error;sourcepath=PlanTests.swift;linenumber=43;columnnumber=5]Recorded an issue (Expectation failed)"
         XCTAssertEqual(formatted, expectedOutput)
     }
 
@@ -772,7 +772,14 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
     func testSwiftTestingIssueDetails() {
         let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
         let formatted = logFormatted(input)
-        let expectedOutput = "##vso[task.logissue type=error]Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
+        let expectedOutput = "##vso[task.logissue type=error;sourcepath=PlanTests.swift;linenumber=43;columnnumber=5]Recorded an issue (Expectation failed)"
+        XCTAssertEqual(formatted, expectedOutput)
+    }
+
+    func testSwiftTestingIssueWithoutDetailsProvidesFileOnlyAnnotation() {
+        let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5"#
+        let formatted = logFormatted(input)
+        let expectedOutput = "##vso[task.logissue type=error;sourcepath=PlanTests.swift;linenumber=43;columnnumber=5]Recorded an issue"
         XCTAssertEqual(formatted, expectedOutput)
     }
 

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -755,7 +755,7 @@ final class GitHubActionsRendererTests: XCTestCase {
     func testSwiftTestingIssue() {
         let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
         let formatted = logFormatted(input)
-        let expectedOutput = "::error ::Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
+        let expectedOutput = "::error file=PlanTests.swift,line=43,col=5::Recorded an issue (Expectation failed)"
         XCTAssertEqual(formatted, expectedOutput)
     }
 
@@ -769,7 +769,14 @@ final class GitHubActionsRendererTests: XCTestCase {
     func testSwiftTestingIssueDetails() {
         let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
         let formatted = logFormatted(input)
-        let expectedOutput = "::error ::Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
+        let expectedOutput = "::error file=PlanTests.swift,line=43,col=5::Recorded an issue (Expectation failed)"
+        XCTAssertEqual(formatted, expectedOutput)
+    }
+
+    func testSwiftTestingIssueWithoutDetailsProvidesFileOnlyAnnotation() {
+        let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5"#
+        let formatted = logFormatted(input)
+        let expectedOutput = "::error file=PlanTests.swift,line=43,col=5::Recorded an issue"
         XCTAssertEqual(formatted, expectedOutput)
     }
 


### PR DESCRIPTION
Ensures that we get the valid file/line/col output when we have Swift Testing test failures when using the github actions renderer, which allows swift testing failures to render inline in the github PR diff UI