### PR TITLE
Refactor release workflow to use gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,19 +36,19 @@ jobs:
           swift-version: ${{ env.SWIFT_VERSION }}
       - name: Build & Package
         run: make package
-      - name: Upload Darwin Universal
+      - name: Upload Darwin Universal Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mv release/xcbeautify.zip "xcbeautify-${{ env.TAG }}-universal-apple-macosx.zip"
           gh release upload "${{ env.TAG }}" "xcbeautify-${{ env.TAG }}-universal-apple-macosx.zip" --clobber
-      - name: Upload Darwin x86_64
+      - name: Upload Darwin x86_64 Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mv .build/x86_64-apple-macosx/release/xcbeautify.zip "xcbeautify-${{ env.TAG }}-x86_64-apple-macosx.zip"
           gh release upload "${{ env.TAG }}" "xcbeautify-${{ env.TAG }}-x86_64-apple-macosx.zip" --clobber
-      - name: Upload Darwin arm64
+      - name: Upload Darwin arm64 Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,12 @@ name: Release
 env:
   # TODO: Load from `.swift-version` file
   SWIFT_VERSION: 6.1
+  TAG: ${{ github.ref_name }}
 
 jobs:
   create_release:
     name: Create Release
     runs-on: ubuntu-latest
-    outputs:
-      tag_name: ${{ steps.create_release.outputs.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -22,9 +21,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${GITHUB_REF##*/}"
-          gh release create "$TAG" --title "$TAG" --generate-notes
-          echo "tag_name=$TAG" >> "$GITHUB_OUTPUT"
+          gh release create "${{ env.TAG }}" --title "${{ env.TAG }}" --generate-notes
 
   macos:
     name: Release macOS
@@ -42,23 +39,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${{ needs.create_release.outputs.tag_name }}"
-          mv release/xcbeautify.zip "xcbeautify-${TAG}-universal-apple-macosx.zip"
-          gh release upload "$TAG" "xcbeautify-${TAG}-universal-apple-macosx.zip" --clobber
+          mv release/xcbeautify.zip "xcbeautify-${{ env.TAG }}-universal-apple-macosx.zip"
+          gh release upload "${{ env.TAG }}" "xcbeautify-${{ env.TAG }}-universal-apple-macosx.zip" --clobber
       - name: Upload Darwin x86_64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${{ needs.create_release.outputs.tag_name }}"
-          mv .build/x86_64-apple-macosx/release/xcbeautify.zip "xcbeautify-${TAG}-x86_64-apple-macosx.zip"
-          gh release upload "$TAG" "xcbeautify-${TAG}-x86_64-apple-macosx.zip" --clobber
+          mv .build/x86_64-apple-macosx/release/xcbeautify.zip "xcbeautify-${{ env.TAG }}-x86_64-apple-macosx.zip"
+          gh release upload "${{ env.TAG }}" "xcbeautify-${{ env.TAG }}-x86_64-apple-macosx.zip" --clobber
       - name: Upload Darwin arm64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${{ needs.create_release.outputs.tag_name }}"
-          mv .build/arm64-apple-macosx/release/xcbeautify.zip "xcbeautify-${TAG}-arm64-apple-macosx.zip"
-          gh release upload "$TAG" "xcbeautify-${TAG}-arm64-apple-macosx.zip" --clobber
+          mv .build/arm64-apple-macosx/release/xcbeautify.zip "xcbeautify-${{ env.TAG }}-arm64-apple-macosx.zip"
+          gh release upload "${{ env.TAG }}" "xcbeautify-${{ env.TAG }}-arm64-apple-macosx.zip" --clobber
 
   ubuntu_x86_64:
     name: Release Linux x86_64
@@ -79,6 +73,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${{ needs.create_release.outputs.tag_name }}"
-          mv xcbeautify.tar.xz "xcbeautify-${TAG}-x86_64-unknown-linux-gnu.tar.xz"
-          gh release upload "$TAG" "xcbeautify-${TAG}-x86_64-unknown-linux-gnu.tar.xz" --clobber
+          mv xcbeautify.tar.xz "xcbeautify-${{ env.TAG }}-x86_64-unknown-linux-gnu.tar.xz"
+          gh release upload "${{ env.TAG }}" "xcbeautify-${{ env.TAG }}-x86_64-unknown-linux-gnu.tar.xz" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,21 +43,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ needs.create_release.outputs.tag_name }}"
-          cp release/xcbeautify.zip "xcbeautify-${TAG}-universal-apple-macosx.zip"
+          mv release/xcbeautify.zip "xcbeautify-${TAG}-universal-apple-macosx.zip"
           gh release upload "$TAG" "xcbeautify-${TAG}-universal-apple-macosx.zip" --clobber
       - name: Upload Darwin x86_64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ needs.create_release.outputs.tag_name }}"
-          cp .build/x86_64-apple-macosx/release/xcbeautify.zip "xcbeautify-${TAG}-x86_64-apple-macosx.zip"
+          mv .build/x86_64-apple-macosx/release/xcbeautify.zip "xcbeautify-${TAG}-x86_64-apple-macosx.zip"
           gh release upload "$TAG" "xcbeautify-${TAG}-x86_64-apple-macosx.zip" --clobber
       - name: Upload Darwin arm64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ needs.create_release.outputs.tag_name }}"
-          cp .build/arm64-apple-macosx/release/xcbeautify.zip "xcbeautify-${TAG}-arm64-apple-macosx.zip"
+          mv .build/arm64-apple-macosx/release/xcbeautify.zip "xcbeautify-${TAG}-arm64-apple-macosx.zip"
           gh release upload "$TAG" "xcbeautify-${TAG}-arm64-apple-macosx.zip" --clobber
 
   ubuntu_x86_64:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
+name: Release
+
 on:
   push:
     tags:
       - "*"
-name: Release
 
 env:
   # TODO: Load from `.swift-version` file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,18 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      tag_name: ${{ steps.get_version.outputs.version }}
+      tag_name: ${{ steps.create_release.outputs.tag_name }}
     steps:
-      - name: Create Release
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Create release via gh
         id: create_release
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-      - id: get_version
-        uses: battila7/get-version-action@v2
+        run: |
+          TAG="${GITHUB_REF##*/}"
+          gh release create "$TAG" --title "$TAG" --generate-notes
+          echo "tag_name=$TAG" >> "$GITHUB_OUTPUT"
 
   macos:
     name: Release macOS
@@ -39,33 +38,27 @@ jobs:
           swift-version: ${{ env.SWIFT_VERSION }}
       - name: Build & Package
         run: make package
-      - name: Darwin Universal
-        uses: actions/upload-release-asset@v1.0.2
+      - name: Upload Darwin Universal
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: release/xcbeautify.zip
-          asset_name: xcbeautify-${{ needs.create_release.outputs.tag_name }}-universal-apple-macosx.zip
-          asset_content_type: application/zip
-      - name: Darwin x86_64
-        uses: actions/upload-release-asset@v1.0.2
+        run: |
+          TAG="${{ needs.create_release.outputs.tag_name }}"
+          cp release/xcbeautify.zip "xcbeautify-${TAG}-universal-apple-macosx.zip"
+          gh release upload "$TAG" "xcbeautify-${TAG}-universal-apple-macosx.zip" --clobber
+      - name: Upload Darwin x86_64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: .build/x86_64-apple-macosx/release/xcbeautify.zip
-          asset_name: xcbeautify-${{ needs.create_release.outputs.tag_name }}-x86_64-apple-macosx.zip
-          asset_content_type: application/zip
-      - name: Darwin arm64
-        uses: actions/upload-release-asset@v1.0.2
+        run: |
+          TAG="${{ needs.create_release.outputs.tag_name }}"
+          cp .build/x86_64-apple-macosx/release/xcbeautify.zip "xcbeautify-${TAG}-x86_64-apple-macosx.zip"
+          gh release upload "$TAG" "xcbeautify-${TAG}-x86_64-apple-macosx.zip" --clobber
+      - name: Upload Darwin arm64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: .build/arm64-apple-macosx/release/xcbeautify.zip
-          asset_name: xcbeautify-${{ needs.create_release.outputs.tag_name }}-arm64-apple-macosx.zip
-          asset_content_type: application/zip
+        run: |
+          TAG="${{ needs.create_release.outputs.tag_name }}"
+          cp .build/arm64-apple-macosx/release/xcbeautify.zip "xcbeautify-${TAG}-arm64-apple-macosx.zip"
+          gh release upload "$TAG" "xcbeautify-${TAG}-arm64-apple-macosx.zip" --clobber
 
   ubuntu_x86_64:
     name: Release Linux x86_64
@@ -82,12 +75,10 @@ jobs:
         run: echo "$GITHUB_WORKSPACE/swift-${{ env.SWIFT_VERSION }}-RELEASE-ubuntu22.04/usr/bin" >> $GITHUB_PATH
       - name: Package Linux x86_64
         run: make package-linux-x86_64
-      - name: Upload Release Asset for Linux x86_64
-        uses: actions/upload-release-asset@v1.0.2
+      - name: Upload Linux x86_64 Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: xcbeautify.tar.xz
-          asset_name: xcbeautify-${{ needs.create_release.outputs.tag_name }}-x86_64-unknown-linux-gnu.tar.xz
-          asset_content_type: application/x-xz
+        run: |
+          TAG="${{ needs.create_release.outputs.tag_name }}"
+          mv xcbeautify.tar.xz "xcbeautify-${TAG}-x86_64-unknown-linux-gnu.tar.xz"
+          gh release upload "$TAG" "xcbeautify-${TAG}-x86_64-unknown-linux-gnu.tar.xz" --clobber


### PR DESCRIPTION
Replaces actions/upload-release-asset with gh CLI commands for uploading release assets. Simplifies release creation and asset upload steps, removes unused get-version action, and updates asset naming and upload logic for macOS and Linux builds.