### PR TITLE
Address deprecation warnings in CI output

### DIFF
--- a/Tests/XcbeautifyLibTests/JUnitReporterTests.swift
+++ b/Tests/XcbeautifyLibTests/JUnitReporterTests.swift
@@ -227,7 +227,7 @@ import XcbeautifyLib
         let parser = Parser()
         let reporter = JUnitReporter()
 
-        for line in try String(contentsOf: url).components(separatedBy: .newlines) {
+        for line in try String(contentsOf: url, encoding: .utf8).components(separatedBy: .newlines) {
             if let captureGroup = parser.parse(line: line) as? any JUnitReportable {
                 reporter.add(captureGroup: captureGroup)
             }
@@ -291,7 +291,7 @@ import XcbeautifyLib
         let parser = Parser()
         let reporter = JUnitReporter()
 
-        for line in try String(contentsOf: url).components(separatedBy: .newlines) {
+        for line in try String(contentsOf: url, encoding: .utf8).components(separatedBy: .newlines) {
             if let captureGroup = parser.parse(line: line) as? any JUnitReportable {
                 reporter.add(captureGroup: captureGroup)
             }
@@ -821,14 +821,14 @@ import XcbeautifyLib
         let parser = Parser()
         let reporter = JUnitReporter()
 
-        for line in try String(contentsOf: inputURL).components(separatedBy: .newlines) {
+        for line in try String(contentsOf: inputURL, encoding: .utf8).components(separatedBy: .newlines) {
             if let captureGroup = parser.parse(line: line) as? any JUnitReportable {
                 reporter.add(captureGroup: captureGroup)
             }
         }
         let data = try reporter.generateReport()
         let actualXML = String(decoding: data, as: UTF8.self)
-        let expectedXML = try String(contentsOf: outputURL)
+        let expectedXML = try String(contentsOf: outputURL, encoding: .utf8)
         #expect(actualXML == expectedXML)
     }
 }


### PR DESCRIPTION
👋  Hi @cpisciotta, I just came across `xcbeautify` today, thank you for making it!

I noticed a bunch of deprecation warnings in the CI output, like this:

```
/home/runner/work/xcbeautify/xcbeautify/Tests/XcbeautifyLibTests/ParsingTests.swift:18:38: warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead [#DeprecatedDeclaration]
 16 |         let url = try #require(Bundle.module.url(forResource: "clean_build_xcode_15_1", withExtension: "txt"))
 17 | 
 18 |         var buildLog: [String] = try String(contentsOf: url)
    |                                      `- warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead [#DeprecatedDeclaration]
 19 |             .components(separatedBy: .newlines)
 20 | 

/home/runner/work/xcbeautify/xcbeautify/Tests/XcbeautifyLibTests/ParsingTests.swift:48:38: warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead [#DeprecatedDeclaration]
 46 |         let url = try #require(Bundle.module.url(forResource: "large_xcodebuild_log", withExtension: "txt"))
 47 | 
 48 |         var buildLog: [String] = try String(contentsOf: url)
    |                                      `- warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead [#DeprecatedDeclaration]
 49 |             .components(separatedBy: .newlines)
 50 | 
```

The changes in here should address the issue.

Here's where the warnings originate: https://github.com/swiftlang/swift-corelibs-foundation/blob/main/Sources/Foundation/NSStringAPI.swift#L273-L283