### PR TITLE
Add a "make deps" command, for local dev

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew "swiftformat"

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,10 @@ export_coverage:
 measure:
 	tools/measure
 	
+.PHONY: deps
+deps:
+	brew bundle
+
 .PHONY: xcode
 xcode:
 	open Package.swift


### PR DESCRIPTION
I ran into `error: SwiftFormat not installed` when I tried using `make lint` - so I added this shortcut for installing local dev dependencies.

(No worries if you're not a fan of the `Brewfile` for this sort of workflow, of course!)