### PR TITLE
Replace Colorizer

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "f227ab50c47f6984542511fcdc3641eb844756adb01e3e1f3ca2ca93fbd79fb1",
+  "originHash" : "f1067b9bf38476e86b942c7d5118ece0657d952a4029b58dd7139dddde7a115d",
   "pins" : [
-    {
-      "identity" : "colorizer",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/getGuaka/Colorizer.git",
-      "state" : {
-        "revision" : "2ccc99bf1715e73c4139e8d40b6e6b30be975586",
-        "version" : "0.2.1"
-      }
-    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -16,10 +16,6 @@ let package = Package(
             from: "1.5.0"
         ),
         .package(
-            url: "https://github.com/getGuaka/Colorizer.git",
-            from: "0.2.1"
-        ),
-        .package(
             url: "https://github.com/CoreOffice/XMLCoder.git",
             from: "0.17.1"
         ),
@@ -35,7 +31,6 @@ let package = Package(
         .target(
             name: "XcbeautifyLib",
             dependencies: [
-                "Colorizer",
                 "XMLCoder",
             ]
         ),

--- a/Sources/XcbeautifyLib/Renderers/TeamCityRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/TeamCityRenderer.swift
@@ -7,7 +7,6 @@
 // See https://github.com/cpisciotta/xcbeautify/blob/main/LICENSE for license information
 //
 
-import Colorizer
 import Foundation
 
 struct TeamCityRenderer: OutputRendering {

--- a/Sources/XcbeautifyLib/Renderers/TerminalRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/TerminalRenderer.swift
@@ -7,7 +7,6 @@
 // See https://github.com/cpisciotta/xcbeautify/blob/main/LICENSE for license information
 //
 
-import Colorizer
 import Foundation
 
 struct TerminalRenderer: OutputRendering {

--- a/Sources/XcbeautifyLib/String+Colored.swift
+++ b/Sources/XcbeautifyLib/String+Colored.swift
@@ -14,12 +14,12 @@ import Foundation
 private let startOfCode = "\u{001B}["
 private let reset = "\u{001B}[0m"
 
-extension String {
-    fileprivate func color(_ color: Color) -> String {
+private extension String {
+    func color(_ color: Color) -> String {
         applyCode(color.rawValue)
     }
 
-    fileprivate func style(_ style: Style) -> String {
+    func style(_ style: Style) -> String {
         applyCode(style.rawValue)
     }
 

--- a/Sources/XcbeautifyLib/String+Colored.swift
+++ b/Sources/XcbeautifyLib/String+Colored.swift
@@ -9,6 +9,129 @@
 
 import Foundation
 
+// MARK: - Apply ANSI codes to a string
+
+private let startOfCode = "\u{001B}["
+private let reset = "\u{001B}[0m"
+
+private extension String {
+    func color(_ color: Color) -> String {
+        colorize(code: color.rawValue)
+    }
+
+    func style(_ style: Style) -> String {
+        colorize(code: style.rawValue)
+    }
+
+    private func colorize(code: Int) -> String {
+        if contains(startOfCode) {
+            colorizeStringAndAddCodeSeparators(code: code)
+        } else {
+            colorizeStringWithoutPriorCode(code: code)
+        }
+    }
+
+    private func colorizeStringWithoutPriorCode(code: Int) -> String {
+        "\(preparedColorCode(code))\(self)\(reset)"
+    }
+
+    private func colorizeStringAndAddCodeSeparators(code: Int) -> String {
+        // To refactor and use regex matching instead of replacing strings and using tricks
+        let stringByRemovingEnding = removeEndingCode()
+        let stringWithStart = "\(preparedColorCode(code))\(stringByRemovingEnding)"
+
+        let stringByAddingCodeSeparator = stringWithStart.addCommandSeparators()
+
+        return "\(stringByAddingCodeSeparator)\(reset)"
+    }
+
+    private func preparedColorCode(_ code: Int) -> String {
+        "\(startOfCode)\(code)m"
+    }
+
+    private func addCommandSeparators() -> String {
+        var rangeWithInset = index(after: startIndex)..<index(before: endIndex)
+        let newString = replacingOccurrences(of: startOfCode, with: ";", options: .literal, range: rangeWithInset)
+
+        rangeWithInset = newString.index(after: newString.startIndex)..<newString.index(before: newString.endIndex)
+        return newString.replacingOccurrences(of: "m;", with: ";", options: .literal, range: rangeWithInset)
+    }
+
+    private func removeEndingCode() -> String {
+        guard !isEmpty else { return self }
+        let rangeWithInset = index(after: startIndex)..<endIndex
+        return replacingOccurrences(of: reset, with: "", options: .literal, range: rangeWithInset)
+    }
+}
+
+// MARK: - Color Codes
+
+private enum Color: Int {
+    case red = 31
+    case green = 32
+    case yellow = 33
+    case cyan = 36
+}
+
+private enum Style: Int {
+    case bold = 1
+    case italic = 3
+}
+
+// MARK: - String Extensions
+
+extension String {
+    struct StringForegroundColorizer {
+        let string: String
+
+        var Red: String {
+            string.color(.red)
+        }
+
+        var Yellow: String {
+            string.color(.yellow)
+        }
+
+        var Green: String {
+            string.color(.green)
+        }
+
+        var Cyan: String {
+            string.color(.cyan)
+        }
+    }
+
+    struct StringStyleColorizer {
+        let string: String
+
+        var Bold: String {
+            string.style(.bold)
+        }
+
+        var Italic: String {
+            string.style(.italic)
+        }
+    }
+
+    var foreground: StringForegroundColorizer {
+        StringForegroundColorizer(string: self)
+    }
+
+    var f: StringForegroundColorizer {
+        foreground
+    }
+
+    var style: StringStyleColorizer {
+        StringStyleColorizer(string: self)
+    }
+
+    var s: StringStyleColorizer {
+        style
+    }
+}
+
+// MARK: - Colored Time and Deviation
+
 extension String {
     func coloredTime() -> String {
         guard let time = Double(self) else { return self }


### PR DESCRIPTION
Remove the `Colorizer` dependency with a native implementation for string coloring and styling using ANSI codes. This change simplifies dependency management and keeps all color/styling logic within the codebase.