### PR TITLE
Update ParsingTests

### DIFF
--- a/Tests/XcbeautifyLibTests/ParsingTests.swift
+++ b/Tests/XcbeautifyLibTests/ParsingTests.swift
@@ -42,7 +42,7 @@ import Testing
     }
 
     @Test func cleanBuildXcode15_1() throws {
-        let uncapturedOutput = try uncapturedOutput(for: "clean_build_xcode_15_1_log")
+        let uncapturedOutput = try uncapturedOutput(for: "clean_build_xcode_15_1")
 
         #if os(macOS)
         #expect(uncapturedOutput == 45)

--- a/Tests/XcbeautifyLibTests/ParsingTests.swift
+++ b/Tests/XcbeautifyLibTests/ParsingTests.swift
@@ -32,7 +32,7 @@ import Testing
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
         // Slowly, this value should decrease until it reaches 0.
-        // It uses `XCTAssertEqual` instead of `XCTAssertLessThanOrEqual` as a reminder.
+        // It uses `==` instead of `<=` as a reminder.
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
@@ -40,6 +40,29 @@ import Testing
         #else
         #expect(uncapturedOutput == 61)
         #endif
+    }
+
+    @Test func demoSwiftTestingOutput() throws {
+        let url = try #require(Bundle.module.url(forResource: "demo_swift_testing_log", withExtension: "txt"))
+        let logContent = try String(contentsOf: url, encoding: .utf8)
+        var buildLog = logContent.components(separatedBy: .newlines)
+        let parser = Parser()
+        var uncapturedOutput = 0
+
+        while !buildLog.isEmpty {
+            let line = buildLog.removeFirst()
+            if !line.isEmpty, parser.parse(line: line) == nil {
+                uncapturedOutput += 1
+            }
+        }
+
+        // The following is a magic number.
+        // It represents the number of lines that aren't captured by the Parser.
+        // Slowly, this value should decrease until it reaches 0.
+        // It uses `==` instead of `<=` as a reminder.
+        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
+        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
+        #expect(uncapturedOutput == 2)
     }
 
     @Test func largeXcodebuildLog() throws {
@@ -62,7 +85,7 @@ import Testing
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
         // Slowly, this value should decrease until it reaches 0.
-        // It uses `XCTAssertEqual` instead of `XCTAssertLessThanOrEqual` as a reminder.
+        // It uses `==` instead of `<=` as a reminder.
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
@@ -72,8 +95,88 @@ import Testing
         #endif
     }
 
-    @Test func parsingSwiftTestingTestOutput() throws {
-        let url = try #require(Bundle.module.url(forResource: "swift_test_log_macOS", withExtension: "txt"))
+    @Test func mixedTestLog60Linux() throws {
+        let url = try #require(Bundle.module.url(forResource: "MixedTestLog_6_0_Linux", withExtension: "txt"))
+
+        var buildLog: [String] = try String(contentsOf: url, encoding: .utf8)
+            .components(separatedBy: .newlines)
+
+        let parser = Parser()
+
+        var uncapturedOutput = 0
+
+        while !buildLog.isEmpty {
+            let line = buildLog.removeFirst()
+            if !line.isEmpty, parser.parse(line: line) == nil {
+                uncapturedOutput += 1
+            }
+        }
+
+        // The following is a magic number.
+        // It represents the number of lines that aren't captured by the Parser.
+        // Slowly, this value should decrease until it reaches 0.
+        // It uses `==` instead of `<=` as a reminder.
+        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
+        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
+        #if os(macOS)
+        #expect(uncapturedOutput == 10)
+        #else
+        #expect(uncapturedOutput == 2)
+        #endif
+    }
+
+    @Test func mixedTestLog60MacOS() throws {
+        let url = try #require(Bundle.module.url(forResource: "MixedTestLog_6_0_macOS", withExtension: "txt"))
+
+        var buildLog: [String] = try String(contentsOf: url, encoding: .utf8)
+            .components(separatedBy: .newlines)
+
+        let parser = Parser()
+
+        var uncapturedOutput = 0
+
+        while !buildLog.isEmpty {
+            let line = buildLog.removeFirst()
+            if !line.isEmpty, parser.parse(line: line) == nil {
+                uncapturedOutput += 1
+            }
+        }
+
+        // The following is a magic number.
+        // It represents the number of lines that aren't captured by the Parser.
+        // Slowly, this value should decrease until it reaches 0.
+        // It uses `==` instead of `<=` as a reminder.
+        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
+        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
+        #if os(macOS)
+        #expect(uncapturedOutput == 3)
+        #else
+        #expect(uncapturedOutput == 6)
+        #endif
+    }
+
+    @Test func parallelTestLog() throws {
+        let url = try #require(Bundle.module.url(forResource: "ParallelTestLog", withExtension: "txt"))
+
+        var buildLog: [String] = try String(contentsOf: url, encoding: .utf8)
+            .components(separatedBy: .newlines)
+
+        let parser = Parser()
+
+        var uncapturedOutput = 0
+
+        while !buildLog.isEmpty {
+            let line = buildLog.removeFirst()
+            if !line.isEmpty, parser.parse(line: line) == nil {
+                uncapturedOutput += 1
+            }
+        }
+
+        #expect(uncapturedOutput == 0)
+    }
+
+    @Test func fullSPISwiftTestingOutput() throws {
+        let url = try #require(Bundle.module.url(forResource: "spi_swift_testing_full_log", withExtension: "txt"))
         let logContent = try String(contentsOf: url, encoding: .utf8)
         var buildLog = logContent.components(separatedBy: .newlines)
         let parser = Parser()
@@ -82,7 +185,6 @@ import Testing
         while !buildLog.isEmpty {
             let line = buildLog.removeFirst()
             if !line.isEmpty, parser.parse(line: line) == nil {
-                print(line)
                 uncapturedOutput += 1
             }
         }
@@ -90,13 +192,13 @@ import Testing
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
         // Slowly, this value should decrease until it reaches 0.
-        // It uses `XCTAssertEqual` instead of `XCTAssertLessThanOrEqual` as a reminder.
+        // It uses `==` instead of `<=` as a reminder.
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
-        #expect(uncapturedOutput == 162)
+        #expect(uncapturedOutput == 2199)
         #else
-        #expect(uncapturedOutput == 271)
+        #expect(uncapturedOutput == 2198)
         #endif
     }
 
@@ -117,7 +219,7 @@ import Testing
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
         // Slowly, this value should decrease until it reaches 0.
-        // It uses `XCTAssertEqual` instead of `XCTAssertLessThanOrEqual` as a reminder.
+        // It uses `==` instead of `<=` as a reminder.
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
@@ -127,8 +229,8 @@ import Testing
         #endif
     }
 
-    @Test func fullSPISwiftTestingOutput() throws {
-        let url = try #require(Bundle.module.url(forResource: "spi_swift_testing_full_log", withExtension: "txt"))
+    @Test func parsingSwiftTestingTestOutput() throws {
+        let url = try #require(Bundle.module.url(forResource: "swift_test_log_macOS", withExtension: "txt"))
         let logContent = try String(contentsOf: url, encoding: .utf8)
         var buildLog = logContent.components(separatedBy: .newlines)
         let parser = Parser()
@@ -144,18 +246,18 @@ import Testing
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
         // Slowly, this value should decrease until it reaches 0.
-        // It uses `XCTAssertEqual` instead of `XCTAssertLessThanOrEqual` as a reminder.
+        // It uses `==` instead of `<=` as a reminder.
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
-        #expect(uncapturedOutput == 2199)
+        #expect(uncapturedOutput == 162)
         #else
-        #expect(uncapturedOutput == 2198)
+        #expect(uncapturedOutput == 271)
         #endif
     }
 
-    @Test func demoSwiftTestingOutput() throws {
-        let url = try #require(Bundle.module.url(forResource: "demo_swift_testing_log", withExtension: "txt"))
+    @Test func testLog() throws {
+        let url = try #require(Bundle.module.url(forResource: "TestLog", withExtension: "txt"))
         let logContent = try String(contentsOf: url, encoding: .utf8)
         var buildLog = logContent.components(separatedBy: .newlines)
         let parser = Parser()
@@ -171,9 +273,13 @@ import Testing
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
         // Slowly, this value should decrease until it reaches 0.
-        // It uses `XCTAssertEqual` instead of `XCTAssertLessThanOrEqual` as a reminder.
+        // It uses `==` instead of `<=` as a reminder.
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
-        #expect(uncapturedOutput == 2)
+        #if os(macOS)
+        #expect(uncapturedOutput == 3)
+        #else
+        #expect(uncapturedOutput == 84)
+        #endif
     }
 }

--- a/Tests/XcbeautifyLibTests/ParsingTests.swift
+++ b/Tests/XcbeautifyLibTests/ParsingTests.swift
@@ -12,8 +12,12 @@ import Testing
 @testable import XcbeautifyLib
 
 @Suite struct ParsingTests {
-    @Test func cleanBuildXcode15_1() throws {
-        let url = try #require(Bundle.module.url(forResource: "clean_build_xcode_15_1", withExtension: "txt"))
+
+    private func uncapturedOutput(
+        for resource: String,
+        withExtension `extension`: String = "txt"
+    ) throws -> Int {
+        let url = try #require(Bundle.module.url(forResource: resource, withExtension: `extension`))
 
         var buildLog: [String] = try String(contentsOf: url, encoding: .utf8)
             .components(separatedBy: .newlines)
@@ -28,6 +32,12 @@ import Testing
                 uncapturedOutput += 1
             }
         }
+
+        return uncapturedOutput
+    }
+
+    @Test func cleanBuildXcode15_1() throws {
+        let uncapturedOutput = try self.uncapturedOutput(for: "clean_build_xcode_15_1_log")
 
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
@@ -43,18 +53,7 @@ import Testing
     }
 
     @Test func demoSwiftTestingOutput() throws {
-        let url = try #require(Bundle.module.url(forResource: "demo_swift_testing_log", withExtension: "txt"))
-        let logContent = try String(contentsOf: url, encoding: .utf8)
-        var buildLog = logContent.components(separatedBy: .newlines)
-        let parser = Parser()
-        var uncapturedOutput = 0
-
-        while !buildLog.isEmpty {
-            let line = buildLog.removeFirst()
-            if !line.isEmpty, parser.parse(line: line) == nil {
-                uncapturedOutput += 1
-            }
-        }
+        let uncapturedOutput = try self.uncapturedOutput(for: "demo_swift_testing_log")
 
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
@@ -66,21 +65,7 @@ import Testing
     }
 
     @Test func largeXcodebuildLog() throws {
-        let url = try #require(Bundle.module.url(forResource: "large_xcodebuild_log", withExtension: "txt"))
-
-        var buildLog: [String] = try String(contentsOf: url, encoding: .utf8)
-            .components(separatedBy: .newlines)
-
-        let parser = Parser()
-
-        var uncapturedOutput = 0
-
-        while !buildLog.isEmpty {
-            let line = buildLog.removeFirst()
-            if !line.isEmpty, parser.parse(line: line) == nil {
-                uncapturedOutput += 1
-            }
-        }
+        let uncapturedOutput = try self.uncapturedOutput(for: "large_xcodebuild_log")
 
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
@@ -96,21 +81,7 @@ import Testing
     }
 
     @Test func mixedTestLog60Linux() throws {
-        let url = try #require(Bundle.module.url(forResource: "MixedTestLog_6_0_Linux", withExtension: "txt"))
-
-        var buildLog: [String] = try String(contentsOf: url, encoding: .utf8)
-            .components(separatedBy: .newlines)
-
-        let parser = Parser()
-
-        var uncapturedOutput = 0
-
-        while !buildLog.isEmpty {
-            let line = buildLog.removeFirst()
-            if !line.isEmpty, parser.parse(line: line) == nil {
-                uncapturedOutput += 1
-            }
-        }
+        let uncapturedOutput = try self.uncapturedOutput(for: "MixedTestLog_6_0_Linux")
 
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
@@ -126,21 +97,7 @@ import Testing
     }
 
     @Test func mixedTestLog60MacOS() throws {
-        let url = try #require(Bundle.module.url(forResource: "MixedTestLog_6_0_macOS", withExtension: "txt"))
-
-        var buildLog: [String] = try String(contentsOf: url, encoding: .utf8)
-            .components(separatedBy: .newlines)
-
-        let parser = Parser()
-
-        var uncapturedOutput = 0
-
-        while !buildLog.isEmpty {
-            let line = buildLog.removeFirst()
-            if !line.isEmpty, parser.parse(line: line) == nil {
-                uncapturedOutput += 1
-            }
-        }
+        let uncapturedOutput = try self.uncapturedOutput(for: "MixedTestLog_6_0_macOS")
 
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
@@ -156,38 +113,12 @@ import Testing
     }
 
     @Test func parallelTestLog() throws {
-        let url = try #require(Bundle.module.url(forResource: "ParallelTestLog", withExtension: "txt"))
-
-        var buildLog: [String] = try String(contentsOf: url, encoding: .utf8)
-            .components(separatedBy: .newlines)
-
-        let parser = Parser()
-
-        var uncapturedOutput = 0
-
-        while !buildLog.isEmpty {
-            let line = buildLog.removeFirst()
-            if !line.isEmpty, parser.parse(line: line) == nil {
-                uncapturedOutput += 1
-            }
-        }
-
+        let uncapturedOutput = try self.uncapturedOutput(for: "ParallelTestLog")
         #expect(uncapturedOutput == 0)
     }
 
     @Test func fullSPISwiftTestingOutput() throws {
-        let url = try #require(Bundle.module.url(forResource: "spi_swift_testing_full_log", withExtension: "txt"))
-        let logContent = try String(contentsOf: url, encoding: .utf8)
-        var buildLog = logContent.components(separatedBy: .newlines)
-        let parser = Parser()
-        var uncapturedOutput = 0
-
-        while !buildLog.isEmpty {
-            let line = buildLog.removeFirst()
-            if !line.isEmpty, parser.parse(line: line) == nil {
-                uncapturedOutput += 1
-            }
-        }
+        let uncapturedOutput = try self.uncapturedOutput(for: "spi_swift_testing_full_log")
 
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
@@ -203,18 +134,7 @@ import Testing
     }
 
     @Test func shortSPISwiftTestingOutput() throws {
-        let url = try #require(Bundle.module.url(forResource: "spi_swift_testing_short_log", withExtension: "txt"))
-        let logContent = try String(contentsOf: url, encoding: .utf8)
-        var buildLog = logContent.components(separatedBy: .newlines)
-        let parser = Parser()
-        var uncapturedOutput = 0
-
-        while !buildLog.isEmpty {
-            let line = buildLog.removeFirst()
-            if !line.isEmpty, parser.parse(line: line) == nil {
-                uncapturedOutput += 1
-            }
-        }
+        let uncapturedOutput = try self.uncapturedOutput(for: "spi_swift_testing_short_log")
 
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
@@ -230,18 +150,7 @@ import Testing
     }
 
     @Test func parsingSwiftTestingTestOutput() throws {
-        let url = try #require(Bundle.module.url(forResource: "swift_test_log_macOS", withExtension: "txt"))
-        let logContent = try String(contentsOf: url, encoding: .utf8)
-        var buildLog = logContent.components(separatedBy: .newlines)
-        let parser = Parser()
-        var uncapturedOutput = 0
-
-        while !buildLog.isEmpty {
-            let line = buildLog.removeFirst()
-            if !line.isEmpty, parser.parse(line: line) == nil {
-                uncapturedOutput += 1
-            }
-        }
+        let uncapturedOutput = try self.uncapturedOutput(for: "swift_test_log_macOS")
 
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.
@@ -257,18 +166,7 @@ import Testing
     }
 
     @Test func testLog() throws {
-        let url = try #require(Bundle.module.url(forResource: "TestLog", withExtension: "txt"))
-        let logContent = try String(contentsOf: url, encoding: .utf8)
-        var buildLog = logContent.components(separatedBy: .newlines)
-        let parser = Parser()
-        var uncapturedOutput = 0
-
-        while !buildLog.isEmpty {
-            let line = buildLog.removeFirst()
-            if !line.isEmpty, parser.parse(line: line) == nil {
-                uncapturedOutput += 1
-            }
-        }
+        let uncapturedOutput = try self.uncapturedOutput(for: "TestLog")
 
         // The following is a magic number.
         // It represents the number of lines that aren't captured by the Parser.

--- a/Tests/XcbeautifyLibTests/ParsingTests.swift
+++ b/Tests/XcbeautifyLibTests/ParsingTests.swift
@@ -13,6 +13,12 @@ import Testing
 
 @Suite struct ParsingTests {
 
+    // These test cases use magic numbers to represent the number of lines that aren't captured by the Parser.
+    // Slowly, the values should decrease until they reach 0.
+    // Test cases uses `==` instead of `<=` as a reminder.
+    // Update the magic numbers whenever `uncapturedOutput` is less than the current magic number.
+    // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
+
     private func uncapturedOutput(
         for resource: String,
         withExtension `extension`: String = "txt"
@@ -39,12 +45,6 @@ import Testing
     @Test func cleanBuildXcode15_1() throws {
         let uncapturedOutput = try self.uncapturedOutput(for: "clean_build_xcode_15_1_log")
 
-        // The following is a magic number.
-        // It represents the number of lines that aren't captured by the Parser.
-        // Slowly, this value should decrease until it reaches 0.
-        // It uses `==` instead of `<=` as a reminder.
-        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
-        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
         #expect(uncapturedOutput == 45)
         #else
@@ -54,25 +54,12 @@ import Testing
 
     @Test func demoSwiftTestingOutput() throws {
         let uncapturedOutput = try self.uncapturedOutput(for: "demo_swift_testing_log")
-
-        // The following is a magic number.
-        // It represents the number of lines that aren't captured by the Parser.
-        // Slowly, this value should decrease until it reaches 0.
-        // It uses `==` instead of `<=` as a reminder.
-        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
-        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #expect(uncapturedOutput == 2)
     }
 
     @Test func largeXcodebuildLog() throws {
         let uncapturedOutput = try self.uncapturedOutput(for: "large_xcodebuild_log")
 
-        // The following is a magic number.
-        // It represents the number of lines that aren't captured by the Parser.
-        // Slowly, this value should decrease until it reaches 0.
-        // It uses `==` instead of `<=` as a reminder.
-        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
-        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
         #expect(uncapturedOutput == 1508)
         #else
@@ -83,12 +70,6 @@ import Testing
     @Test func mixedTestLog60Linux() throws {
         let uncapturedOutput = try self.uncapturedOutput(for: "MixedTestLog_6_0_Linux")
 
-        // The following is a magic number.
-        // It represents the number of lines that aren't captured by the Parser.
-        // Slowly, this value should decrease until it reaches 0.
-        // It uses `==` instead of `<=` as a reminder.
-        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
-        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
         #expect(uncapturedOutput == 10)
         #else
@@ -99,12 +80,6 @@ import Testing
     @Test func mixedTestLog60MacOS() throws {
         let uncapturedOutput = try self.uncapturedOutput(for: "MixedTestLog_6_0_macOS")
 
-        // The following is a magic number.
-        // It represents the number of lines that aren't captured by the Parser.
-        // Slowly, this value should decrease until it reaches 0.
-        // It uses `==` instead of `<=` as a reminder.
-        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
-        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
         #expect(uncapturedOutput == 3)
         #else
@@ -120,12 +95,6 @@ import Testing
     @Test func fullSPISwiftTestingOutput() throws {
         let uncapturedOutput = try self.uncapturedOutput(for: "spi_swift_testing_full_log")
 
-        // The following is a magic number.
-        // It represents the number of lines that aren't captured by the Parser.
-        // Slowly, this value should decrease until it reaches 0.
-        // It uses `==` instead of `<=` as a reminder.
-        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
-        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
         #expect(uncapturedOutput == 2199)
         #else
@@ -136,12 +105,6 @@ import Testing
     @Test func shortSPISwiftTestingOutput() throws {
         let uncapturedOutput = try self.uncapturedOutput(for: "spi_swift_testing_short_log")
 
-        // The following is a magic number.
-        // It represents the number of lines that aren't captured by the Parser.
-        // Slowly, this value should decrease until it reaches 0.
-        // It uses `==` instead of `<=` as a reminder.
-        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
-        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
         #expect(uncapturedOutput == 10)
         #else
@@ -152,12 +115,6 @@ import Testing
     @Test func parsingSwiftTestingTestOutput() throws {
         let uncapturedOutput = try self.uncapturedOutput(for: "swift_test_log_macOS")
 
-        // The following is a magic number.
-        // It represents the number of lines that aren't captured by the Parser.
-        // Slowly, this value should decrease until it reaches 0.
-        // It uses `==` instead of `<=` as a reminder.
-        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
-        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
         #expect(uncapturedOutput == 162)
         #else
@@ -168,12 +125,6 @@ import Testing
     @Test func testLog() throws {
         let uncapturedOutput = try self.uncapturedOutput(for: "TestLog")
 
-        // The following is a magic number.
-        // It represents the number of lines that aren't captured by the Parser.
-        // Slowly, this value should decrease until it reaches 0.
-        // It uses `==` instead of `<=` as a reminder.
-        // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
-        // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
         #expect(uncapturedOutput == 3)
         #else

--- a/Tests/XcbeautifyLibTests/ParsingTests.swift
+++ b/Tests/XcbeautifyLibTests/ParsingTests.swift
@@ -12,7 +12,6 @@ import Testing
 @testable import XcbeautifyLib
 
 @Suite struct ParsingTests {
-
     // These test cases use magic numbers to represent the number of lines that aren't captured by the Parser.
     // Slowly, the values should decrease until they reach 0.
     // Test cases uses `==` instead of `<=` as a reminder.
@@ -21,7 +20,7 @@ import Testing
 
     private func uncapturedOutput(
         for resource: String,
-        withExtension `extension`: String = "txt"
+        withExtension extension: String = "txt"
     ) throws -> Int {
         let url = try #require(Bundle.module.url(forResource: resource, withExtension: `extension`))
 
@@ -43,7 +42,7 @@ import Testing
     }
 
     @Test func cleanBuildXcode15_1() throws {
-        let uncapturedOutput = try self.uncapturedOutput(for: "clean_build_xcode_15_1_log")
+        let uncapturedOutput = try uncapturedOutput(for: "clean_build_xcode_15_1_log")
 
         #if os(macOS)
         #expect(uncapturedOutput == 45)
@@ -53,12 +52,12 @@ import Testing
     }
 
     @Test func demoSwiftTestingOutput() throws {
-        let uncapturedOutput = try self.uncapturedOutput(for: "demo_swift_testing_log")
+        let uncapturedOutput = try uncapturedOutput(for: "demo_swift_testing_log")
         #expect(uncapturedOutput == 2)
     }
 
     @Test func largeXcodebuildLog() throws {
-        let uncapturedOutput = try self.uncapturedOutput(for: "large_xcodebuild_log")
+        let uncapturedOutput = try uncapturedOutput(for: "large_xcodebuild_log")
 
         #if os(macOS)
         #expect(uncapturedOutput == 1508)
@@ -68,7 +67,7 @@ import Testing
     }
 
     @Test func mixedTestLog60Linux() throws {
-        let uncapturedOutput = try self.uncapturedOutput(for: "MixedTestLog_6_0_Linux")
+        let uncapturedOutput = try uncapturedOutput(for: "MixedTestLog_6_0_Linux")
 
         #if os(macOS)
         #expect(uncapturedOutput == 10)
@@ -78,7 +77,7 @@ import Testing
     }
 
     @Test func mixedTestLog60MacOS() throws {
-        let uncapturedOutput = try self.uncapturedOutput(for: "MixedTestLog_6_0_macOS")
+        let uncapturedOutput = try uncapturedOutput(for: "MixedTestLog_6_0_macOS")
 
         #if os(macOS)
         #expect(uncapturedOutput == 3)
@@ -88,12 +87,12 @@ import Testing
     }
 
     @Test func parallelTestLog() throws {
-        let uncapturedOutput = try self.uncapturedOutput(for: "ParallelTestLog")
+        let uncapturedOutput = try uncapturedOutput(for: "ParallelTestLog")
         #expect(uncapturedOutput == 0)
     }
 
     @Test func fullSPISwiftTestingOutput() throws {
-        let uncapturedOutput = try self.uncapturedOutput(for: "spi_swift_testing_full_log")
+        let uncapturedOutput = try uncapturedOutput(for: "spi_swift_testing_full_log")
 
         #if os(macOS)
         #expect(uncapturedOutput == 2199)
@@ -103,7 +102,7 @@ import Testing
     }
 
     @Test func shortSPISwiftTestingOutput() throws {
-        let uncapturedOutput = try self.uncapturedOutput(for: "spi_swift_testing_short_log")
+        let uncapturedOutput = try uncapturedOutput(for: "spi_swift_testing_short_log")
 
         #if os(macOS)
         #expect(uncapturedOutput == 10)
@@ -113,7 +112,7 @@ import Testing
     }
 
     @Test func parsingSwiftTestingTestOutput() throws {
-        let uncapturedOutput = try self.uncapturedOutput(for: "swift_test_log_macOS")
+        let uncapturedOutput = try uncapturedOutput(for: "swift_test_log_macOS")
 
         #if os(macOS)
         #expect(uncapturedOutput == 162)
@@ -123,7 +122,7 @@ import Testing
     }
 
     @Test func testLog() throws {
-        let uncapturedOutput = try self.uncapturedOutput(for: "TestLog")
+        let uncapturedOutput = try uncapturedOutput(for: "TestLog")
 
         #if os(macOS)
         #expect(uncapturedOutput == 3)


### PR DESCRIPTION
This pull request refactors the `ParsingTests.swift` test suite to reduce code duplication and improve maintainability. The main change is the introduction of a helper function to calculate uncaptured output lines for different test log resources, which simplifies and unifies the test cases. Each test now uses this helper, making the suite more concise and easier to update as the parser improves.

**Test suite refactoring and simplification:**

* Introduced a private helper function `uncapturedOutput(for:withExtension:)` that encapsulates the logic for counting uncaptured lines in a log file, removing repeated code from each test case.
* Updated all test cases to use the new helper, significantly reducing code duplication and making it easier to update the "magic numbers" as the parser improves.

**Test case organization and clarity improvements:**

* Added and reordered test cases to consistently use the new helper, clarified comments about magic numbers, and ensured all tests use `#expect(uncapturedOutput == X)` for regression tracking.