### PR TITLE
Refactor XCRegex

### DIFF
--- a/Sources/XcbeautifyLib/XCRegex.swift
+++ b/Sources/XcbeautifyLib/XCRegex.swift
@@ -9,19 +9,17 @@
 
 import Foundation
 
-// `NSRegularExpression` is marked as `@unchecked Sendable`.
-// Match the definition here.
-package final class XCRegex: @unchecked Sendable {
-    private let pattern: String
+package struct XCRegex: Sendable {
+    private let regex: NSRegularExpression?
 
-    private lazy var regex: NSRegularExpression? = {
+    private static func makeRegex(pattern: String) -> NSRegularExpression? {
         let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
         assert(regex != nil)
         return regex
-    }()
+    }
 
     init(pattern: String) {
-        self.pattern = pattern
+        regex = Self.makeRegex(pattern: pattern)
     }
 
     func captureGroups(for line: String) -> [String]? {


### PR DESCRIPTION
Changed XCRegex from a final class to a struct conforming to Sendable. Refactored regex initialization to occur in the initializer instead of using a lazy property, improving clarity and thread safety.