### PR TITLE
Add separate static Linux release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 env:
   # TODO: Load from `.swift-version` file
   SWIFT_VERSION: 6.1
+  SWIFT_STATIC_SDK_URL: https://download.swift.org/swift-6.1-release/static-sdk/swift-6.1-RELEASE/swift-6.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz
+  SWIFT_STATIC_SDK_CHECKSUM: 111c6f7d280a651208b8c74c0521dd99365d785c1976a6e23162f55f65379ac6
   TAG: ${{ github.ref_name }}
 
 jobs:
@@ -68,6 +70,8 @@ jobs:
         run: tar xzf swift-${{ env.SWIFT_VERSION }}-RELEASE-ubuntu22.04.tar.gz
       - name: Add Swift toolchain to PATH
         run: echo "$GITHUB_WORKSPACE/swift-${{ env.SWIFT_VERSION }}-RELEASE-ubuntu22.04/usr/bin" >> $GITHUB_PATH
+      - name: Install Swift Static Linux SDK
+        run: swift sdk install "${{ env.SWIFT_STATIC_SDK_URL }}" --checksum "${{ env.SWIFT_STATIC_SDK_CHECKSUM }}"
       - name: Package Linux x86_64
         run: make package-linux-x86_64
       - name: Upload Linux x86_64 Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,6 @@ jobs:
         run: tar xzf swift-${{ env.SWIFT_VERSION }}-RELEASE-ubuntu22.04.tar.gz
       - name: Add Swift toolchain to PATH
         run: echo "$GITHUB_WORKSPACE/swift-${{ env.SWIFT_VERSION }}-RELEASE-ubuntu22.04/usr/bin" >> $GITHUB_PATH
-      - name: Install Swift Static Linux SDK
-        run: swift sdk install "${{ env.SWIFT_STATIC_SDK_URL }}" --checksum "${{ env.SWIFT_STATIC_SDK_CHECKSUM }}"
       - name: Package Linux x86_64
         run: make package-linux-x86_64
       - name: Upload Linux x86_64 Asset
@@ -80,6 +78,22 @@ jobs:
         run: |
           mv xcbeautify.tar.xz "xcbeautify-${{ env.TAG }}-x86_64-unknown-linux-gnu.tar.xz"
           gh release upload "${{ env.TAG }}" "xcbeautify-${{ env.TAG }}-x86_64-unknown-linux-gnu.tar.xz" --clobber
+
+  ubuntu_x86_64_static:
+    name: Release Linux x86_64 Static
+    runs-on: ubuntu-22.04
+    needs: create_release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Download Swift ${{ env.SWIFT_VERSION }}
+        run: wget https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/ubuntu2204/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-ubuntu22.04.tar.gz
+      - name: Extract Swift ${{ env.SWIFT_VERSION }}
+        run: tar xzf swift-${{ env.SWIFT_VERSION }}-RELEASE-ubuntu22.04.tar.gz
+      - name: Add Swift toolchain to PATH
+        run: echo "$GITHUB_WORKSPACE/swift-${{ env.SWIFT_VERSION }}-RELEASE-ubuntu22.04/usr/bin" >> $GITHUB_PATH
+      - name: Install Swift Static Linux SDK
+        run: swift sdk install "${{ env.SWIFT_STATIC_SDK_URL }}" --checksum "${{ env.SWIFT_STATIC_SDK_CHECKSUM }}"
       - name: Package Linux x86_64 Static
         run: make package-linux-x86_64-static
       - name: Upload Linux x86_64 Static Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,3 +80,11 @@ jobs:
         run: |
           mv xcbeautify.tar.xz "xcbeautify-${{ env.TAG }}-x86_64-unknown-linux-gnu.tar.xz"
           gh release upload "${{ env.TAG }}" "xcbeautify-${{ env.TAG }}-x86_64-unknown-linux-gnu.tar.xz" --clobber
+      - name: Package Linux x86_64 Static
+        run: make package-linux-x86_64-static
+      - name: Upload Linux x86_64 Static Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mv xcbeautify.tar.xz "xcbeautify-${{ env.TAG }}-x86_64-linux-static.tar.xz"
+          gh release upload "${{ env.TAG }}" "xcbeautify-${{ env.TAG }}-x86_64-linux-static.tar.xz" --clobber

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,16 @@ package-darwin-universal:
 
 .PHONY: package-linux-x86_64
 package-linux-x86_64:
+	$(eval TARGET_TRIPLE := x86_64-unknown-linux-gnu)
+	$(eval SWIFT_BUILD_FLAGS := $(SHARED_SWIFT_BUILD_FLAGS) --triple $(TARGET_TRIPLE))
+	$(eval BUILD_DIRECTORY := $(shell swift build --show-bin-path $(SWIFT_BUILD_FLAGS)))
+	docker run --rm --volume `pwd`:/workdir --workdir /workdir \
+		swift:6.1 swift build $(SWIFT_BUILD_FLAGS)
+	tar --directory "$(BUILD_DIRECTORY)" --create --xz --file \
+		"$(PRODUCT_NAME).tar.xz" "$(PRODUCT_NAME)"
+
+.PHONY: package-linux-x86_64-static
+package-linux-x86_64-static:
 	$(eval SWIFT_SDK := x86_64-swift-linux-musl)
 	$(eval SWIFT_BUILD_FLAGS := $(SHARED_SWIFT_BUILD_FLAGS) --product $(PRODUCT_NAME) --swift-sdk $(SWIFT_SDK))
 	$(eval BUILD_DIRECTORY := $(shell swift build --show-bin-path $(SWIFT_BUILD_FLAGS)))

--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,10 @@ package-darwin-universal:
 
 .PHONY: package-linux-x86_64
 package-linux-x86_64:
-	$(eval TARGET_TRIPLE := x86_64-unknown-linux-gnu)
-	$(eval SWIFT_BUILD_FLAGS := $(SHARED_SWIFT_BUILD_FLAGS) --triple $(TARGET_TRIPLE))
+	$(eval SWIFT_SDK := x86_64-swift-linux-musl)
+	$(eval SWIFT_BUILD_FLAGS := $(SHARED_SWIFT_BUILD_FLAGS) --product $(PRODUCT_NAME) --swift-sdk $(SWIFT_SDK))
 	$(eval BUILD_DIRECTORY := $(shell swift build --show-bin-path $(SWIFT_BUILD_FLAGS)))
-	docker run --rm --volume `pwd`:/workdir --workdir /workdir \
-		swift:6.1 swift build $(SWIFT_BUILD_FLAGS)
+	$(SWIFT) build $(SWIFT_BUILD_FLAGS)
 	tar --directory "$(BUILD_DIRECTORY)" --create --xz --file \
 		"$(PRODUCT_NAME).tar.xz" "$(PRODUCT_NAME)"
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GIT=/usr/bin/git
 MKDIR=/bin/mkdir -p
 RM=/bin/rm -rf
 SED=/usr/bin/sed
-SWIFT=/usr/bin/swift
+SWIFT?=swift
 ZIP=/usr/bin/zip -r
 
 SHARED_SWIFT_BUILD_FLAGS = --configuration release --disable-sandbox
@@ -33,7 +33,7 @@ build:
 package-darwin-x86_64:
 	$(eval TARGET_TRIPLE := x86_64-apple-macosx)
 	$(eval SWIFT_BUILD_FLAGS := $(SHARED_SWIFT_BUILD_FLAGS) --triple $(TARGET_TRIPLE))
-	$(eval BUILD_DIRECTORY := $(shell swift build --show-bin-path $(SWIFT_BUILD_FLAGS)))
+	$(eval BUILD_DIRECTORY := $(shell $(SWIFT) build --show-bin-path $(SWIFT_BUILD_FLAGS)))
 	$(SWIFT) build $(SWIFT_BUILD_FLAGS)
 	$(CD) "$(BUILD_DIRECTORY)" && $(ZIP) "$(PRODUCT_NAME).zip" "$(PRODUCT_NAME)"
 
@@ -41,7 +41,7 @@ package-darwin-x86_64:
 package-darwin-arm64:
 	$(eval TARGET_TRIPLE := arm64-apple-macosx)
 	$(eval SWIFT_BUILD_FLAGS := $(SHARED_SWIFT_BUILD_FLAGS) --triple $(TARGET_TRIPLE))
-	$(eval BUILD_DIRECTORY := $(shell swift build --show-bin-path $(SWIFT_BUILD_FLAGS)))
+	$(eval BUILD_DIRECTORY := $(shell $(SWIFT) build --show-bin-path $(SWIFT_BUILD_FLAGS)))
 	$(SWIFT) build $(SWIFT_BUILD_FLAGS)
 	$(CD) "$(BUILD_DIRECTORY)" && $(ZIP) "$(PRODUCT_NAME).zip" "$(PRODUCT_NAME)"
 
@@ -49,12 +49,12 @@ package-darwin-arm64:
 package-darwin-universal:
 	$(eval X86_64_TARGET_TRIPLE := x86_64-apple-macosx)
 	$(eval X86_64_SWIFT_BUILD_FLAGS := $(SHARED_SWIFT_BUILD_FLAGS) --triple $(X86_64_TARGET_TRIPLE))
-	$(eval X86_64_BUILD_DIRECTORY := $(shell swift build --show-bin-path $(X86_64_SWIFT_BUILD_FLAGS)))
+	$(eval X86_64_BUILD_DIRECTORY := $(shell $(SWIFT) build --show-bin-path $(X86_64_SWIFT_BUILD_FLAGS)))
 	$(SWIFT) build $(X86_64_SWIFT_BUILD_FLAGS)
 
 	$(eval ARM64_TARGET_TRIPLE := arm64-apple-macosx)
 	$(eval ARM64_SWIFT_BUILD_FLAGS := $(SHARED_SWIFT_BUILD_FLAGS) --triple $(ARM64_TARGET_TRIPLE))
-	$(eval ARM64_BUILD_DIRECTORY := $(shell swift build --show-bin-path $(ARM64_SWIFT_BUILD_FLAGS)))
+	$(eval ARM64_BUILD_DIRECTORY := $(shell $(SWIFT) build --show-bin-path $(ARM64_SWIFT_BUILD_FLAGS)))
 	$(SWIFT) build $(ARM64_SWIFT_BUILD_FLAGS)
 
 	$(eval RELEASE_DIR := release)
@@ -68,7 +68,7 @@ package-darwin-universal:
 package-linux-x86_64:
 	$(eval TARGET_TRIPLE := x86_64-unknown-linux-gnu)
 	$(eval SWIFT_BUILD_FLAGS := $(SHARED_SWIFT_BUILD_FLAGS) --triple $(TARGET_TRIPLE))
-	$(eval BUILD_DIRECTORY := $(shell swift build --show-bin-path $(SWIFT_BUILD_FLAGS)))
+	$(eval BUILD_DIRECTORY := $(shell $(SWIFT) build --show-bin-path $(SWIFT_BUILD_FLAGS)))
 	docker run --rm --volume `pwd`:/workdir --workdir /workdir \
 		swift:6.1 swift build $(SWIFT_BUILD_FLAGS)
 	tar --directory "$(BUILD_DIRECTORY)" --create --xz --file \
@@ -78,7 +78,7 @@ package-linux-x86_64:
 package-linux-x86_64-static:
 	$(eval SWIFT_SDK := x86_64-swift-linux-musl)
 	$(eval SWIFT_BUILD_FLAGS := $(SHARED_SWIFT_BUILD_FLAGS) --product $(PRODUCT_NAME) --swift-sdk $(SWIFT_SDK))
-	$(eval BUILD_DIRECTORY := $(shell swift build --show-bin-path $(SWIFT_BUILD_FLAGS)))
+	$(eval BUILD_DIRECTORY := $(shell $(SWIFT) build --show-bin-path $(SWIFT_BUILD_FLAGS)))
 	$(SWIFT) build $(SWIFT_BUILD_FLAGS)
 	tar --directory "$(BUILD_DIRECTORY)" --create --xz --file \
 		"$(PRODUCT_NAME).tar.xz" "$(PRODUCT_NAME)"
@@ -93,15 +93,15 @@ install-swift:
 package-linux-arm64: install-swift
 	$(eval TARGET_TRIPLE := aarch64-unknown-linux-gnu)
 	$(eval SWIFT_BUILD_FLAGS := $(SHARED_SWIFT_BUILD_FLAGS) --triple $(TARGET_TRIPLE))
-	$(eval BUILD_DIRECTORY := $(shell swift build --show-bin-path $(SWIFT_BUILD_FLAGS)))
-	swift build $(SWIFT_BUILD_FLAGS)
+	$(eval BUILD_DIRECTORY := $(shell $(SWIFT) build --show-bin-path $(SWIFT_BUILD_FLAGS)))
+	$(SWIFT) build $(SWIFT_BUILD_FLAGS)
 	tar --directory "$(BUILD_DIRECTORY)" --create --xz --file \
 		"$(PRODUCT_NAME).tar.xz" "$(PRODUCT_NAME)"
 
 .PHONY: install
 install: build
 	$(eval BINARY_DIRECTORY := $(PREFIX)/bin)
-	$(eval BUILD_DIRECTORY := $(shell swift build --show-bin-path $(SHARED_SWIFT_BUILD_FLAGS)))
+	$(eval BUILD_DIRECTORY := $(shell $(SWIFT) build --show-bin-path $(SHARED_SWIFT_BUILD_FLAGS)))
 	$(MKDIR) $(BINARY_DIRECTORY)
 	$(CP) "$(BUILD_DIRECTORY)/$(PRODUCT_NAME)" "$(BINARY_DIRECTORY)"
 


### PR DESCRIPTION
Add a new `x86_64-linux-static` Linux release artifact for `xcbeautify`.

This PR updates the release packaging so each tagged release produces two x86_64 Linux assets:
- the existing `x86_64-unknown-linux-gnu` tarball
- a new self-contained `x86_64-linux-static` tarball built with Swift's official static musl SDK

## Overview
- add a dedicated `package-linux-x86_64-static` Make target
- keep the existing GNU/Linux packaging path intact
- update the release workflow to install the matching Swift static Linux SDK
- upload both Linux artifacts from the release workflow

## Why
Today the GNU Linux release tarball contains only the `xcbeautify` binary, but that binary is dynamically linked against Swift runtime libraries such as `libswiftCore.so`. That makes it awkward for downstream package managers that expect a standalone binary artifact.

The new static asset provides a self-contained Linux binary without changing the existing GNU asset.

Precedent:
- [SwiftFormat](https://github.com/nicklockwood/SwiftFormat/blob/main/.github/workflows/release.yml) ships self-contained Linux release binaries as `swiftformat_linux.zip` and `swiftformat_linux_aarch64.zip`.
- [SwiftLint](https://github.com/realm/SwiftLint/blob/main/.github/workflows/release.yml) ships both regular Linux binaries and separate static Linux artifacts built with Swift's static Linux SDK.

## Test plan
- [x] `swift test`
- [x] Verified the static SDK URL and checksum used in the workflow resolve successfully
- [x] Built both Linux artifacts locally in `swift:6.1` with `--platform linux/amd64`
- [x] Confirmed the GNU artifact is dynamically linked and still depends on `libswift*.so`
- [x] Confirmed the `x86_64-linux-static` artifact is statically linked, has no `NEEDED` / `RUNPATH` entries, and `./xcbeautify --help` runs in the container
- End-to-end GitHub release workflow not run locally

---
*This response was drafted with AI assistance.*
