### PR TITLE
Use XCBeautifier in CLI

### DIFF
--- a/Sources/XcbeautifyLib/XCBeautifier.swift
+++ b/Sources/XcbeautifyLib/XCBeautifier.swift
@@ -9,6 +9,17 @@
 
 import Foundation
 
+/// The result of processing a single log line through `XCBeautifier`.
+package struct FormattingResult {
+    /// The matched capture group, or `nil` when the line was unrecognized but preserved.
+    package let captureGroup: (any CaptureGroup)?
+    /// The output type used for routing (e.g. through `OutputHandler`).
+    package let outputType: OutputType
+    /// The formatted string, or `nil` when the renderer has no output for a recognized group.
+    /// For preserved-unbeautified lines this is the original raw line.
+    package let formatted: String?
+}
+
 /// The single type responsible for formatting output.
 public struct XCBeautifier {
     private let parser = Parser()
@@ -49,5 +60,21 @@ public struct XCBeautifier {
         }
 
         return formatter.format(captureGroup: captureGroup)
+    }
+
+    /// Processes a single raw log line and returns a `FormattingResult` for routing and reporting.
+    /// - Parameter line: The raw `xcodebuild` or `swift` output line.
+    /// - Returns: A `FormattingResult` when the line is recognized or `preserveUnbeautifiedLines` is `true`; `nil` otherwise.
+    package func process(line: String) -> FormattingResult? {
+        guard let captureGroup = parser.parse(line: line) else {
+            guard preserveUnbeautifiedLines else { return nil }
+            return FormattingResult(captureGroup: nil, outputType: .undefined, formatted: line)
+        }
+
+        return FormattingResult(
+            captureGroup: captureGroup,
+            outputType: captureGroup.outputType,
+            formatted: formatter.format(captureGroup: captureGroup)
+        )
     }
 }

--- a/Sources/XcbeautifyLib/XCBeautifier.swift
+++ b/Sources/XcbeautifyLib/XCBeautifier.swift
@@ -51,15 +51,7 @@ public struct XCBeautifier {
     /// - Parameter line: The raw `xcodebuild` output.
     /// - Returns: The formatted output. Returns `nil` if the input is unrecognized, unless `preserveUnbeautifiedLines` is `true`.
     public func format(line: String) -> String? {
-        guard let captureGroup = parser.parse(line: line) else {
-            if preserveUnbeautifiedLines {
-                return line
-            } else {
-                return nil
-            }
-        }
-
-        return formatter.format(captureGroup: captureGroup)
+        process(line: line)?.formatted
     }
 
     /// Processes a single raw log line and returns a `FormattingResult` for routing and reporting.

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -92,34 +92,25 @@ struct Xcbeautify: ParsableCommand {
         let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCI) { print($0) }
         let junitReporter = JUnitReporter()
 
-        let parser = Parser()
-
-        let formatter = XcbeautifyLib.Formatter(
+        let xcbeautifier = XCBeautifier(
             colored: !disableColoredOutput,
             renderer: renderer,
+            preserveUnbeautifiedLines: preserveUnbeautified,
             additionalLines: { readLine() }
         )
 
         while let line = readLine() {
             // Continue if a line is empty or only contains whitespace.
-            // Create a separate variable, since passing a line with trimmed whitespace changes our ability to parse non-empty lines.
             let _line = line.trimmingCharacters(in: .whitespaces)
             guard !_line.isEmpty else { continue }
 
-            guard let captureGroup = parser.parse(line: line) else {
-                if preserveUnbeautified {
-                    output.write(.undefined, line)
-                }
+            guard let result = xcbeautifier.process(line: line) else { continue }
 
-                continue
-            }
-
-            if report.contains(.junit), let captureGroup = captureGroup as? any JUnitReportable {
+            if report.contains(.junit), let captureGroup = result.captureGroup as? any JUnitReportable {
                 junitReporter.add(captureGroup: captureGroup)
             }
 
-            guard let formatted = formatter.format(captureGroup: captureGroup) else { continue }
-            output.write(captureGroup.outputType, formatted)
+            output.write(result.outputType, result.formatted)
         }
 
         if !report.isEmpty {

--- a/Tests/XcbeautifyLibTests/XCBeautifierTests.swift
+++ b/Tests/XcbeautifyLibTests/XCBeautifierTests.swift
@@ -1,0 +1,78 @@
+//
+// XCBeautifierTests.swift
+//
+// Copyright (c) 2026 Charles Pisciotta and other contributors
+// Licensed under MIT License
+//
+// See https://github.com/cpisciotta/xcbeautify/blob/main/LICENSE for license information
+//
+
+import Testing
+@testable import XcbeautifyLib
+
+struct XCBeautifierTests {
+    @Test func processReturnsNilForUnrecognizedLineWhenPreserveDisabled() {
+        let beautifier = XCBeautifier(
+            colored: true,
+            renderer: .terminal,
+            preserveUnbeautifiedLines: false,
+            additionalLines: { nil }
+        )
+
+        let result = beautifier.process(line: "this line is not recognized")
+
+        #expect(result == nil)
+        #expect(beautifier.format(line: "this line is not recognized") == nil)
+    }
+
+    @Test func processPreservesUnrecognizedLineWhenPreserveEnabled() throws {
+        let beautifier = XCBeautifier(
+            colored: true,
+            renderer: .terminal,
+            preserveUnbeautifiedLines: true,
+            additionalLines: { nil }
+        )
+
+        let input = "this line is not recognized"
+        let result = try #require(beautifier.process(line: input))
+
+        #expect(result.captureGroup == nil)
+        #expect(result.outputType == .undefined)
+        #expect(result.formatted == input)
+        #expect(beautifier.format(line: input) == input)
+    }
+
+    @Test func processReturnsCaptureGroupForRecognizedLine() throws {
+        let beautifier = XCBeautifier(
+            colored: true,
+            renderer: .terminal,
+            preserveUnbeautifiedLines: false,
+            additionalLines: { nil }
+        )
+
+        let input = "** BUILD SUCCEEDED **"
+        let result = try #require(beautifier.process(line: input))
+
+        #expect(result.captureGroup is PhaseSuccessCaptureGroup)
+        #expect(result.outputType == .result)
+        #expect(result.formatted == "\u{001B}[32;1mBuild Succeeded\u{001B}[0m")
+        #expect(beautifier.format(line: input) == result.formatted)
+    }
+
+    @Test func processKeepsCaptureGroupWhenFormattedOutputIsNil() throws {
+        let beautifier = XCBeautifier(
+            colored: true,
+            renderer: .terminal,
+            preserveUnbeautifiedLines: false,
+            additionalLines: { nil }
+        )
+
+        let input = "CreateBuildDirectory /Backyard-Birds/Build/Intermediates.noindex/EagerLinkingTBDs/Debug"
+        let result = try #require(beautifier.process(line: input))
+
+        #expect(result.captureGroup is CreateBuildDirectoryCaptureGroup)
+        #expect(result.outputType == .task)
+        #expect(result.formatted == nil)
+        #expect(beautifier.format(line: input) == nil)
+    }
+}


### PR DESCRIPTION
Refactor how log lines are processed and formatted by introducing a new `FormattingResult` struct and centralizing line processing logic within the `XCBeautifier` type. The main changes improve code clarity, make it easier to handle both recognized and unrecognized log lines, and streamline reporting and output handling.

**Core refactoring and API improvements:**

* Introduced the `FormattingResult` struct in `XCBeautifier.swift` to encapsulate the result of processing a log line, including the matched capture group, output type, and formatted string.
* Added a new `process(line:)` method to `XCBeautifier` that returns a `FormattingResult?`, handling both recognized and unrecognized lines (with respect to the `preserveUnbeautifiedLines` flag).

**Command-line tool update:**

* Updated the main loop in `Xcbeautify.swift` to use the new `XCBeautifier.process(line:)` method, simplifying logic for handling formatted output and reporting, and removing direct use of the parser and formatter in the command-line tool.