### PR TITLE
Fix stdout buffering to enable streaming output

### DIFF
--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -8,7 +8,7 @@
 //
 
 import ArgumentParser
-import Foundation
+@preconcurrency import Foundation
 import XcbeautifyLib
 
 @main
@@ -58,6 +58,8 @@ struct Xcbeautify: ParsableCommand {
     var junitReportFilename = "junit.xml"
 
     func run() throws {
+        setvbuf(stdout, nil, _IONBF, 0)
+
         #if DEBUG && os(macOS)
         let start = CFAbsoluteTimeGetCurrent()
 

--- a/tools/cli-tests
+++ b/tools/cli-tests
@@ -43,4 +43,7 @@ for test_dir in Tests/CLITests/*/; do
     fi
 done
 
+echo "Running test: streaming"
+"$(dirname "$0")/test-streaming" ./.build/release/xcbeautify
+
 echo "All CLI tests passed successfully!"

--- a/tools/test-streaming
+++ b/tools/test-streaming
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Verifies that xcbeautify flushes each output line immediately, even
+# when stdout is a pipe.
+#
+# Mechanism: xcbeautify reads from an input FIFO and writes to an output
+# FIFO. The test writes one line at a time, then attempts to read the
+# corresponding output line with a generous timeout. A read that
+# succeeds means the line was flushed; a timeout means it was stuck in
+# a buffer. This avoids sleep-based polling and the flakiness that
+# comes with it.
+
+set -euo pipefail
+
+BIN="${1:-.build/release/xcbeautify}"
+
+IN_FIFO=$(mktemp -u)
+OUT_FIFO=$(mktemp -u)
+mkfifo "$IN_FIFO"
+mkfifo "$OUT_FIFO"
+
+cleanup() { rm -f "$IN_FIFO" "$OUT_FIFO"; }
+trap cleanup EXIT
+
+# Start xcbeautify: reads from IN_FIFO, writes to OUT_FIFO.
+"$BIN" --disable-logging --preserve-unbeautified < "$IN_FIFO" > "$OUT_FIFO" &
+XCB_PID=$!
+
+# Open the write side of IN_FIFO (keeps it open across iterations).
+exec 3>"$IN_FIFO"
+
+# Open the read side of OUT_FIFO.
+exec 4<"$OUT_FIFO"
+
+PASS=true
+
+for i in 1 2 3; do
+    # Send one line.
+    echo "Line $i of input" >&3
+
+    # Read the corresponding output line. 5 s timeout is generous; a
+    # buffered implementation would not flush until the ~4 KB buffer
+    # fills or the process exits, so this would time out.
+    if read -t 5 -u 4 output_line; then
+        if [ "$output_line" != "Line $i of input" ]; then
+            echo "FAIL: Line $i content mismatch: got '$output_line'"
+            PASS=false
+        fi
+    else
+        echo "FAIL: Timed out waiting for line $i (output is buffered)"
+        PASS=false
+    fi
+done
+
+# Close the write side so xcbeautify sees EOF and exits.
+exec 3>&-
+wait "$XCB_PID" 2>/dev/null || true
+
+# Close the read side.
+exec 4<&-
+
+if [ "$PASS" = true ]; then
+    echo "Streaming test passed."
+else
+    echo "Streaming test FAILED."
+    exit 1
+fi

--- a/tools/test-streaming
+++ b/tools/test-streaming
@@ -14,12 +14,16 @@ set -euo pipefail
 
 BIN="${1:-.build/release/xcbeautify}"
 
-IN_FIFO=$(mktemp -u)
-OUT_FIFO=$(mktemp -u)
+TMP_DIR=$(mktemp -d)
+IN_FIFO="$TMP_DIR/in.fifo"
+OUT_FIFO="$TMP_DIR/out.fifo"
 mkfifo "$IN_FIFO"
 mkfifo "$OUT_FIFO"
 
-cleanup() { rm -f "$IN_FIFO" "$OUT_FIFO"; }
+cleanup() {
+    rm -f "$IN_FIFO" "$OUT_FIFO"
+    rmdir "$TMP_DIR" 2>/dev/null || true
+}
 trap cleanup EXIT
 
 # Start xcbeautify: reads from IN_FIFO, writes to OUT_FIFO.


### PR DESCRIPTION
Fixes #481 (`Request: streaming output`).

## Problem

When `xcbeautify` is piped to another process (the typical usage: `xcodebuild ... | xcbeautify | ...`), the C runtime defaults to full buffering for stdout. Since the CLI used `print()` for all output, lines accumulated in a ~4 KB buffer before being flushed to the downstream consumer. This meant CI agents, log watchers, or other tools couldn't see results as they were produced; they had to wait for the buffer to fill or for the process to exit.

## Solution

Add `setvbuf(stdout, nil, _IONBF, 0)` at process start to disable C stdio buffering on stdout. This is a single-line fix that makes all existing `print()` calls flush immediately, with no other code changes needed.

Uses `@preconcurrency import Foundation` to satisfy Swift 6 strict concurrency for the global `stdout` symbol.

### Why `setvbuf` over the alternatives

| Approach | Tradeoff |
|---|---|
| `setvbuf(stdout, nil, _IONBF, 0)` (chosen) | One line, uses standard `print()`, single I/O layer, no error handling needed |
| POSIX `write(STDOUT_FILENO, ...)` | Bypasses stdio entirely but mixes two I/O layers on the same fd, requires manual partial-write and EINTR handling |
| `fflush(stdout)` after each `print` | Requires touching every output site; easy to miss one |

## Changes

- `Sources/xcbeautify/Xcbeautify.swift`: add `setvbuf(stdout, nil, _IONBF, 0)` at the top of `run()` and use `@preconcurrency import Foundation`
- `tools/test-streaming`: add a CLI streaming test using FIFO-to-FIFO reads with `read -t` to verify each line flushes immediately
- `tools/cli-tests`: integrate the streaming test into the existing CLI suite

## Testing

- `swift test`
- `swift build --configuration release -Xswiftc -warnings-as-errors`
- `./tools/lint`
- `./tools/cli-tests`
