### PR TITLE
Add --skip-formatting option to bypass formatting for specific log patterns

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -14,12 +14,25 @@ private let swiftTestingSuiteName = "SwiftTesting"
 package protocol CaptureGroup {
     static var outputType: OutputType { get }
     static var regex: XCRegex { get }
+    static var identifier: String { get }
     init?(groups: [String])
 }
 
 package extension CaptureGroup {
     var outputType: OutputType {
         Self.outputType
+    }
+
+    static var identifier: String {
+        let name = String(describing: Self.self)
+        let trimmed = name.hasSuffix("CaptureGroup")
+            ? String(name.dropLast("CaptureGroup".count))
+            : name
+        return trimmed.kebabCased
+    }
+
+    var identifier: String {
+        Self.identifier
     }
 }
 

--- a/Sources/XcbeautifyLib/String+KebabCase.swift
+++ b/Sources/XcbeautifyLib/String+KebabCase.swift
@@ -1,0 +1,41 @@
+//
+// String+KebabCase.swift
+//
+// Copyright (c) 2026 Charles Pisciotta and other contributors
+// Licensed under MIT License
+//
+// See https://github.com/cpisciotta/xcbeautify/blob/main/LICENSE for license information
+//
+
+import Foundation
+
+package extension String {
+    /// Converts a PascalCase or camelCase string to kebab-case.
+    ///
+    /// Consecutive uppercase letters (acronyms) are kept together as a single
+    /// lowercased segment. A hyphen is inserted before an uppercase letter when
+    /// the previous character is lowercase, or when the next character is
+    /// lowercase (marking the end of an acronym).
+    ///
+    /// Examples:
+    /// - `"FatalError"` -> `"fatal-error"`
+    /// - `"UIFailingTest"` -> `"ui-failing-test"`
+    /// - `"LDError"` -> `"ld-error"`
+    /// - `"GenerateDSYM"` -> `"generate-dsym"`
+    /// - `"already-kebab"` -> `"already-kebab"`
+    var kebabCased: String {
+        let chars = Array(self)
+        var result = ""
+        for (i, char) in chars.enumerated() {
+            if char.isUppercase {
+                let prevIsLower = i > 0 && chars[i - 1].isLowercase
+                let nextIsLower = i + 1 < chars.count && chars[i + 1].isLowercase
+                if i > 0, prevIsLower || nextIsLower {
+                    result.append("-")
+                }
+            }
+            result.append(contentsOf: char.lowercased())
+        }
+        return result
+    }
+}

--- a/Sources/XcbeautifyLib/XCBeautifier.swift
+++ b/Sources/XcbeautifyLib/XCBeautifier.swift
@@ -25,17 +25,20 @@ public struct XCBeautifier {
     private let parser = Parser()
     private let formatter: Formatter
     private let preserveUnbeautifiedLines: Bool
+    private let skippedCaptureGroups: Set<String>
 
     /// Creates an `XCBeautifier` instance.
     /// - Parameters:
     ///   - colored: Indicates if `XCBeautifier` should color its formatted output.
     ///   - renderer: Indicates the context, such as Terminal and GitHub Actions, where `XCBeautifier` is used.
     ///   - preserveUnbeautifiedLines: Indicates if `XCBeautifier` should preserve unrecognized output.
+    ///   - skippedCaptureGroups: A set of capture group identifiers whose formatting should be skipped. Matched lines are emitted as plain text instead.
     ///   - additionalLines: A closure that provides `XCBeautifier` the subsequent console output when needed (i.e. multi-line output).
     public init(
         colored: Bool,
         renderer: Renderer,
         preserveUnbeautifiedLines: Bool,
+        skippedCaptureGroups: Set<String> = [],
         additionalLines: @escaping () -> String?
     ) {
         formatter = Formatter(
@@ -45,6 +48,7 @@ public struct XCBeautifier {
         )
 
         self.preserveUnbeautifiedLines = preserveUnbeautifiedLines
+        self.skippedCaptureGroups = skippedCaptureGroups
     }
 
     /// Formats `xcodebuild` console output.
@@ -61,6 +65,14 @@ public struct XCBeautifier {
         guard let captureGroup = parser.parse(line: line) else {
             guard preserveUnbeautifiedLines else { return nil }
             return FormattingResult(captureGroup: nil, outputType: .undefined, formatted: line)
+        }
+
+        if skippedCaptureGroups.contains(captureGroup.identifier) {
+            return FormattingResult(
+                captureGroup: captureGroup,
+                outputType: captureGroup.outputType,
+                formatted: line
+            )
         }
 
         return FormattingResult(

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -57,6 +57,9 @@ struct Xcbeautify: ParsableCommand {
     @Option(help: "The name of JUnit report file name")
     var junitReportFilename = "junit.xml"
 
+    @Option(name: .long, parsing: .singleValue, help: "Skip formatting for a specific log pattern so it is printed as plain text instead. May be repeated. Pattern identifiers are kebab-case names, e.g. 'fatal-error', 'fatal-error-with-file-path', 'compile-error'.")
+    var skipFormatting: [String] = []
+
     func run() throws {
         #if DEBUG && os(macOS)
         let start = CFAbsoluteTimeGetCurrent()
@@ -86,6 +89,7 @@ struct Xcbeautify: ParsableCommand {
             colored: !disableColoredOutput,
             renderer: renderer,
             preserveUnbeautifiedLines: preserveUnbeautified,
+            skippedCaptureGroups: Set(skipFormatting),
             additionalLines: { readLine() }
         )
 

--- a/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
+++ b/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
@@ -308,4 +308,12 @@ struct CaptureGroupTests {
         #expect(SwiftTestingIssueCaptureGroup.regex.captureGroups(for: input) == nil)
         #expect(SwiftTestingIssueArgumentCaptureGroup.regex.captureGroups(for: input) != nil)
     }
+
+    // MARK: - Capture Group Identifiers
+
+    @Test func captureGroupIdentifierStripsSuffixAndConvertsToKebabCase() {
+        #expect(FatalErrorCaptureGroup.identifier == "fatal-error")
+        #expect(FatalErrorWithFilePathCaptureGroup.identifier == "fatal-error-with-file-path")
+        #expect(UIFailingTestCaptureGroup.identifier == "ui-failing-test")
+    }
 }

--- a/Tests/XcbeautifyLibTests/KebabCaseTests.swift
+++ b/Tests/XcbeautifyLibTests/KebabCaseTests.swift
@@ -1,0 +1,50 @@
+//
+// KebabCaseTests.swift
+//
+// Copyright (c) 2026 Charles Pisciotta and other contributors
+// Licensed under MIT License
+//
+// See https://github.com/cpisciotta/xcbeautify/blob/main/LICENSE for license information
+//
+
+import Testing
+@testable import XcbeautifyLib
+
+struct KebabCaseTests {
+    @Test func simpleWords() {
+        #expect("FatalError".kebabCased == "fatal-error")
+        #expect("CompileWarning".kebabCased == "compile-warning")
+        #expect("PhaseSuccess".kebabCased == "phase-success")
+    }
+
+    @Test func multipleWords() {
+        #expect("FatalErrorWithFilePath".kebabCased == "fatal-error-with-file-path")
+        #expect("LinkerDuplicateSymbols".kebabCased == "linker-duplicate-symbols")
+    }
+
+    @Test func leadingAcronym() {
+        #expect("UIFailingTest".kebabCased == "ui-failing-test")
+        #expect("LDError".kebabCased == "ld-error")
+        #expect("LDWarning".kebabCased == "ld-warning")
+    }
+
+    @Test func trailingAcronym() {
+        #expect("GenerateDSYM".kebabCased == "generate-dsym")
+    }
+
+    @Test func singleWord() {
+        #expect("Compile".kebabCased == "compile")
+    }
+
+    @Test func alreadyLowercase() {
+        #expect("already".kebabCased == "already")
+    }
+
+    @Test func allUppercase() {
+        #expect("DSYM".kebabCased == "dsym")
+    }
+
+    @Test func emptyString() {
+        #expect("".kebabCased == "")
+    }
+}

--- a/Tests/XcbeautifyLibTests/UniqueCaptureGroupTests.swift
+++ b/Tests/XcbeautifyLibTests/UniqueCaptureGroupTests.swift
@@ -212,5 +212,24 @@ struct UniqueCaptureGroupTests {
             )
         }
     }
+
+    @Test func uniqueCaptureGroupIdentifiers() {
+        var seen = [String]()
+        var duplicates = [String]()
+
+        for type in captureGroupTypes {
+            let id = type.identifier
+            if seen.contains(id) {
+                duplicates.append("\(id) (\(String(describing: type)))")
+            } else {
+                seen.append(id)
+            }
+        }
+
+        #expect(
+            duplicates.isEmpty,
+            "Found duplicate capture group identifier(s): \(duplicates.joined(separator: ", "))"
+        )
+    }
     #endif
 }

--- a/Tests/XcbeautifyLibTests/XCBeautifierTests.swift
+++ b/Tests/XcbeautifyLibTests/XCBeautifierTests.swift
@@ -75,4 +75,92 @@ struct XCBeautifierTests {
         #expect(result.formatted == nil)
         #expect(beautifier.format(line: input) == nil)
     }
+
+    // MARK: - Skip Formatting
+
+    @Test func skippedCaptureGroupReturnsRawLineWithOriginalOutputType() throws {
+        let beautifier = XCBeautifier(
+            colored: false,
+            renderer: .azureDevOpsPipelines,
+            preserveUnbeautifiedLines: false,
+            skippedCaptureGroups: ["fatal-error"],
+            additionalLines: { nil }
+        )
+
+        let input = "fatal error: something went wrong"
+        let result = try #require(beautifier.process(line: input))
+
+        #expect(result.captureGroup is FatalErrorCaptureGroup)
+        #expect(result.outputType == .error)
+        #expect(result.formatted == input)
+    }
+
+    @Test func skippedCaptureGroupDoesNotEmitAnnotation() throws {
+        let beautifier = XCBeautifier(
+            colored: false,
+            renderer: .azureDevOpsPipelines,
+            preserveUnbeautifiedLines: false,
+            skippedCaptureGroups: ["fatal-error"],
+            additionalLines: { nil }
+        )
+
+        let input = "fatal error: something went wrong"
+        let result = try #require(beautifier.process(line: input))
+
+        #expect(result.formatted?.hasPrefix("##vso[") != true)
+    }
+
+    @Test func nonSkippedCaptureGroupFormatsNormally() throws {
+        let beautifier = XCBeautifier(
+            colored: false,
+            renderer: .azureDevOpsPipelines,
+            preserveUnbeautifiedLines: false,
+            skippedCaptureGroups: ["fatal-error"],
+            additionalLines: { nil }
+        )
+
+        let input = "fatal error: something went wrong"
+        let skippedResult = try #require(beautifier.process(line: input))
+        #expect(skippedResult.outputType == .error)
+        #expect(skippedResult.formatted == input)
+
+        let otherInput = "xcodebuild: error: something else failed"
+        let normalResult = try #require(beautifier.process(line: otherInput))
+        #expect(normalResult.outputType == .error)
+        #expect(normalResult.formatted?.hasPrefix("##vso[task.logissue type=error]") == true)
+    }
+
+    @Test func skippedFatalErrorWithFilePathReturnsRawLine() throws {
+        let beautifier = XCBeautifier(
+            colored: false,
+            renderer: .gitHubActions,
+            preserveUnbeautifiedLines: false,
+            skippedCaptureGroups: ["fatal-error-with-file-path"],
+            additionalLines: { nil }
+        )
+
+        let input = "Target/File.swift:193: Fatal error: Assertion failed"
+        let result = try #require(beautifier.process(line: input))
+
+        #expect(result.captureGroup is FatalErrorWithFilePathCaptureGroup)
+        #expect(result.outputType == .error)
+        #expect(result.formatted == input)
+        #expect(result.formatted?.hasPrefix("::error") != true)
+    }
+
+    @Test func emptySkippedSetFormatsNormally() throws {
+        let beautifier = XCBeautifier(
+            colored: false,
+            renderer: .azureDevOpsPipelines,
+            preserveUnbeautifiedLines: false,
+            skippedCaptureGroups: [],
+            additionalLines: { nil }
+        )
+
+        let input = "fatal error: something went wrong"
+        let result = try #require(beautifier.process(line: input))
+
+        #expect(result.outputType == .error)
+        #expect(result.formatted?.hasPrefix("##vso[task.logissue type=error]") == true)
+    }
 }


### PR DESCRIPTION
## Summary

New repeatable CLI option `--skip-formatting <identifier>` that skips renderer formatting for specific log patterns. Matched lines are printed as plain text instead of being wrapped in CI annotations.

```sh
xcodebuild test ... | xcbeautify \
  --renderer azure-devops-pipelines \
  --skip-formatting fatal-error \
  --skip-formatting fatal-error-with-file-path
```

A line like `fatal error: unexpected condition` would normally produce:
```
##vso[task.logissue type=error]fatal error: unexpected condition
```
With `--skip-formatting fatal-error`, it is printed as-is:
```
fatal error: unexpected condition
```

## Motivation

When using xcbeautify in CI pipelines, some log output may match error-level capture groups even though the output is harmless or expected. For example, a build log might contain `fatal error:` lines that are not actual build failures, or warning-level output that is known and accepted. Since CI renderers turn these matches into annotations (`##vso[task.logissue type=error]`, `::error::`, etc.), they show up prominently in the build summary — adding noise, hiding real failures, and confusing developers.

The existing `--quiet`/`--quieter` flags control which output types are shown, but they cannot selectively skip formatting for individual patterns. `--skip-formatting` fills that gap: the line still appears in the output with its original output type (so quiet/quieter filtering still works as expected), but the renderer's annotation wrapper is removed.

## Pattern identifiers

Each `CaptureGroup` now exposes an `identifier` derived automatically from its Swift type name: strip the `CaptureGroup` suffix, then convert PascalCase to kebab-case (keeping acronyms together). For example:

| Type | Identifier |
|------|------------|
| `FatalErrorCaptureGroup` | `fatal-error` |
| `FatalErrorWithFilePathCaptureGroup` | `fatal-error-with-file-path` |
| `UIFailingTestCaptureGroup` | `ui-failing-test` |
| `LDErrorCaptureGroup` | `ld-error` |
| `GenerateDSYMCaptureGroup` | `generate-dsym` |

The conversion lives in a reusable `String.kebabCased` extension with its own test suite. No changes to individual capture group structs are needed.
